### PR TITLE
Variants

### DIFF
--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -128,8 +128,8 @@ function utils.has_active_job()
   end
   utils.error(
     "A CMake task is already running: "
-      .. utils.job.command
-      .. " Stop it before trying to run a new CMake task."
+    .. utils.job.command
+    .. " Stop it before trying to run a new CMake task."
   )
   return false
 end
@@ -144,6 +144,18 @@ function utils.get_cmake_configuration()
     )
   end
   return Result:new(Types.SUCCESS, cmakelists, "cmake-tools has found CMakeLists.txt.")
+end
+
+function utils.rmdir(dir)
+  for name, type in vim.fs.dir(dir) do
+    local path = dir .. "/" .. name
+    if type == "file" then
+      os.remove(path)
+    else
+      utils.rmdir(path)
+    end
+  end
+  os.remove(dir)
 end
 
 return utils

--- a/lua/cmake-tools/variants.lua
+++ b/lua/cmake-tools/variants.lua
@@ -15,6 +15,7 @@ local function parse()
           dir = dir:match("%.%./((%.%./)*)")
           if not dir then dir = "./" end
           file = vim.fn.resolve(dir .. f)
+          break
         end
       end
       files = vim.fn.readdir(dir)

--- a/lua/cmake-tools/variants.lua
+++ b/lua/cmake-tools/variants.lua
@@ -55,16 +55,31 @@ function variants.get()
   end
 
   local function create_combinations(choices)
+    -- The following code is a *modified* version of
     -- https://rosettacode.org/wiki/Cartesian_product_of_two_or_more_lists#Functional-esque_(non-iterator)
-    -- Code under CC-BY-SA 4.0
+    -- under CC-BY-SA 4.0
     -- accessed: 01.10.22
     -- BEGIN code from rosettacode
 
     -- support:
-    function T(t) return setmetatable(t, { __index = table }) end
+    local function T(t)
+      return setmetatable(t, { __index = table })
+    end
 
-    table.clone = function(t) local s = T {} for k, v in ipairs(t) do s[k] = v end return s end
-    table.reduce = function(t, f, acc) for i = 1, #t do acc = f(t[i], acc) end return acc end
+    local function clone(t)
+      local s = T {}
+      for k, v in ipairs(t) do
+        s[k] = v
+      end
+      return s
+    end
+
+    local function reduce(t, f, acc)
+      for i = 1, #t do
+        acc = f(t[i], acc)
+      end
+      return acc
+    end
 
     -- implementation:
     local function cartprod(sets)
@@ -72,7 +87,7 @@ function variants.get()
       local function descend(depth)
         for _, v in ipairs(sets[depth]) do
           temp[depth] = v
-          if (depth == #sets) then prod[#prod + 1] = temp:clone() else descend(depth + 1) end
+          if (depth == #sets) then prod[#prod + 1] = clone(temp) else descend(depth + 1) end
         end
       end
 
@@ -83,7 +98,7 @@ function variants.get()
     -- END code from rosettacode
 
     local combinations = cartprod(choices)
-    local strings = combinations:reduce(function(t, a) table.insert(a, t:concat(" + ")); return a end, {})
+    local strings = reduce(combinations, function(t, a) table.insert(a, t:concat(" + ")); return a end, {})
 
     return strings
   end

--- a/lua/cmake-tools/variants.lua
+++ b/lua/cmake-tools/variants.lua
@@ -56,7 +56,9 @@ function variants.get()
 
   local function create_combinations(choices)
     -- https://rosettacode.org/wiki/Cartesian_product_of_two_or_more_lists#Functional-esque_(non-iterator)
+    -- Code under CC-BY-SA 4.0
     -- accessed: 01.10.22
+    -- BEGIN code from rosettacode
 
     -- support:
     function T(t) return setmetatable(t, { __index = table }) end
@@ -78,7 +80,7 @@ function variants.get()
       return prod
     end
 
-    --
+    -- END code from rosettacode
 
     local combinations = cartprod(choices)
     local strings = combinations:reduce(function(t, a) table.insert(a, t:concat(" + ")); return a end, {})

--- a/lua/cmake-tools/variants.lua
+++ b/lua/cmake-tools/variants.lua
@@ -1,0 +1,158 @@
+local variants = {}
+
+local syaml = require("simpleyaml")
+
+local DEFAULT_VARIANTS = { "Debug", "Release", "RelWithDebInfo", "MinSizeRel" }
+
+local function parse()
+  local function findcfg()
+    local files = vim.fn.readdir(".")
+    local file = nil
+    local dir = ".."
+    while files and not file do
+      for _, f in ipairs(files) do
+        if f == "cmake-variants.yaml" or f == "cmake-variants.json" then
+          dir = dir:match("%.%./((%.%./)*)")
+          if not dir then dir = "./" end
+          file = vim.fn.resolve(dir .. f)
+        end
+      end
+      files = vim.fn.readdir(dir)
+      dir = dir .. "/.."
+    end
+
+    return file
+  end
+
+  local config = nil
+
+  local file = findcfg()
+  if file then
+    if file:match(".*%.yaml") then
+      config = syaml.parse_file(file)
+    else
+      config = vim.fn.json_decode(vim.fn.readfile(file))
+    end
+  end
+
+  return config
+end
+
+function variants.get()
+  local function collect_choices(config)
+    local choices = {}
+
+    for _, option in pairs(config) do
+      local cs = {}
+      for _, choice in pairs(option["choices"]) do
+        table.insert(cs, choice["short"])
+      end
+      table.insert(choices, cs)
+    end
+
+    return choices
+  end
+
+  local function create_combinations(choices)
+    -- https://rosettacode.org/wiki/Cartesian_product_of_two_or_more_lists#Functional-esque_(non-iterator)
+    -- accessed: 01.10.22
+
+    -- support:
+    function T(t) return setmetatable(t, { __index = table }) end
+
+    table.clone = function(t) local s = T {} for k, v in ipairs(t) do s[k] = v end return s end
+    table.reduce = function(t, f, acc) for i = 1, #t do acc = f(t[i], acc) end return acc end
+
+    -- implementation:
+    local function cartprod(sets)
+      local temp, prod = T {}, T {}
+      local function descend(depth)
+        for _, v in ipairs(sets[depth]) do
+          temp[depth] = v
+          if (depth == #sets) then prod[#prod + 1] = temp:clone() else descend(depth + 1) end
+        end
+      end
+
+      descend(1)
+      return prod
+    end
+
+    --
+
+    local combinations = cartprod(choices)
+    local strings = combinations:reduce(function(t, a) table.insert(a, t:concat(" + ")); return a end, {})
+
+    return strings
+  end
+
+  local config = parse()
+  if config then
+    local choices = collect_choices(config)
+    local combinations = create_combinations(choices)
+    return combinations
+  end
+
+  return DEFAULT_VARIANTS
+end
+
+function variants.build_arglist(variant)
+  local function build_simple(build_type)
+    return { "-D", "CMAKE_BUILD_TYPE=" .. build_type }
+  end
+
+  for defaultvar in pairs(DEFAULT_VARIANTS) do
+    if variant == defaultvar then
+      return build_simple(variant)
+    end
+  end
+
+  local config = parse()
+  if not config then
+    return {} -- silent error
+  end
+
+  local args = {}
+
+  local function add_args(as)
+    for _, a in pairs(as) do
+      table.insert(args, a)
+    end
+  end
+
+  for choice in string.gmatch(variant, "%s*([^+]+)%s*") do -- split on +
+    local choice_found = false
+    choice = choice:match("^%s*(.-)%s*$") -- trim (or come up with a better regex above)
+    for _, option in pairs(config) do
+      for _, chc in pairs(option["choices"]) do
+        local short = chc["short"]
+        if choice == short then
+          if chc["buildType"] ~= nil then
+            add_args({ "-DCMAKE_BUILD_TYPE=" .. chc["buildType"] })
+          end
+          if chc["settings"] ~= nil then
+            for k, v in pairs(chc["settings"]) do
+              add_args({ "-D" .. k .. "=" .. v })
+            end
+          end
+          if chc["linkage"] ~= nil then
+            local function add_linkage(linkage)
+              add_args({ "-DBUILD_SHARED_LIBS=" .. linkage })
+            end
+
+            if chc["linkage"] == "static" then
+              add_linkage("OFF")
+            elseif chc["linkage"] == "shared" then
+              add_linkage("ON")
+            end
+          end
+          choice_found = true
+          break
+        end
+      end
+      if choice_found then break end
+    end
+  end
+  return args
+end
+
+return variants

--- a/lua/cmake-tools/variants.lua
+++ b/lua/cmake-tools/variants.lua
@@ -90,6 +90,7 @@ function variants.get()
   if config then
     local choices = collect_choices(config)
     local combinations = create_combinations(choices)
+    table.sort(combinations)
     return combinations
   end
 

--- a/lua/cmake-tools/variants.lua
+++ b/lua/cmake-tools/variants.lua
@@ -2,17 +2,21 @@ local variants = {}
 
 local syaml = require("simpleyaml")
 
+-- fallback if no cmake-variants.[yaml|json] is found
 local DEFAULT_VARIANTS = { "Debug", "Release", "RelWithDebInfo", "MinSizeRel" }
 
+-- checks if there is a cmake-variants.[yaml|json] file and parses it to a Lua table
 local function parse()
+  -- helper function to find the config file
+  -- returns file path if found, nil otherwise
   local function findcfg()
     local files = vim.fn.readdir(".")
     local file = nil
     local dir = ".."
-    while files and not file do
-      for _, f in ipairs(files) do
-        if f == "cmake-variants.yaml" or f == "cmake-variants.json" then
-          dir = dir:match("%.%./((%.%./)*)")
+    while files and not file do -- iterate over files in current directory
+       for _, f in ipairs(files) do
+        if f == "cmake-variants.yaml" or f == "cmake-variants.json" then -- if a variants config file is found
+          dir = dir:match("%.%./((%.%./)*)") -- constructi its full path and break the loop
           if not dir then dir = "./" end
           file = vim.fn.resolve(dir .. f)
           break
@@ -25,13 +29,15 @@ local function parse()
     return file
   end
 
+  -- start parsing
+
   local config = nil
 
-  local file = findcfg()
-  if file then
-    if file:match(".*%.yaml") then
+  local file = findcfg() -- check for config file
+  if file then -- if one is found ...
+    if file:match(".*%.yaml") then -- .. and is a YAML file, parse it with simpleyaml
       config = syaml.parse_file(file)
-    else
+    else -- otherwise parse it with neovim's JSON parser
       config = vim.fn.json_decode(vim.fn.readfile(file))
     end
   end
@@ -39,14 +45,16 @@ local function parse()
   return config
 end
 
+-- returns a list of string descriptions of all possible combinations of configurations, using their short names
 function variants.get()
+  -- helper function to collect all short names of choices
   local function collect_choices(config)
     local choices = {}
 
-    for _, option in pairs(config) do
+    for _, option in pairs(config) do -- for all options
       local cs = {}
-      for _, choice in pairs(option["choices"]) do
-        table.insert(cs, choice["short"])
+      for _, choice in pairs(option["choices"]) do -- for all choices of that option
+        table.insert(cs, choice["short"]) -- collect their short name
       end
       table.insert(choices, cs)
     end
@@ -54,6 +62,7 @@ function variants.get()
     return choices
   end
 
+  -- helper function to create all possible combinations of choices (cartesian product)
   local function create_combinations(choices)
     -- The following code is a *modified* version of
     -- https://rosettacode.org/wiki/Cartesian_product_of_two_or_more_lists#Functional-esque_(non-iterator)
@@ -103,57 +112,67 @@ function variants.get()
     return strings
   end
 
+  -- start parsing
+
   local config = parse()
-  if config then
-    local choices = collect_choices(config)
-    local combinations = create_combinations(choices)
-    table.sort(combinations)
+  if config then -- if a config is found
+    local choices = collect_choices(config) -- collect all possible choices from it
+    local combinations = create_combinations(choices) -- calculate the cartesian product
+    table.sort(combinations) -- sort lexicographically
     return combinations
-  end
+  end -- otherwise return the defaults
 
   return DEFAULT_VARIANTS
 end
 
+-- given a variant, build an argument list for CMake
 function variants.build_arglist(variant)
+  -- helper function to build a simple command line option that defines the CMAKE_BUILD_TYPE variable to `build_type`
   local function build_simple(build_type)
     return { "-D", "CMAKE_BUILD_TYPE=" .. build_type }
   end
 
+  -- start building arglist
+
+  -- check if the chosen variants is one of the defaults
   for defaultvar in pairs(DEFAULT_VARIANTS) do
     if variant == defaultvar then
-      return build_simple(variant)
+      return build_simple(variant) -- if so, build the simple arglist and return
     end
   end
 
+  -- otherwise, find the config file to parse
   local config = parse()
   if not config then
-    return {} -- silent error
+    return {} -- silent error (empty arglist) if no config file found
   end
 
   local args = {}
 
+  -- local function to add an argument to `args`
   local function add_args(as)
     for _, a in pairs(as) do
       table.insert(args, a)
     end
   end
 
-  for choice in string.gmatch(variant, "%s*([^+]+)%s*") do -- split on +
+  -- for each choice in the chosen variant
+  for choice in string.gmatch(variant, "%s*([^+]+)%s*") do -- split variant string on + to get choices
     local choice_found = false
     choice = choice:match("^%s*(.-)%s*$") -- trim (or come up with a better regex above)
-    for _, option in pairs(config) do
+    for _, option in pairs(config) do -- search for the choice
       for _, chc in pairs(option["choices"]) do
         local short = chc["short"]
-        if choice == short then
-          if chc["buildType"] ~= nil then
+        if choice == short then -- if the choice is found, add to the argument list according to the defined keys
+          if chc["buildType"] ~= nil then -- CMAKE_BUILD_TYPE
             add_args({ "-DCMAKE_BUILD_TYPE=" .. chc["buildType"] })
           end
-          if chc["settings"] ~= nil then
+          if chc["settings"] ~= nil then -- user DEFINITIONs
             for k, v in pairs(chc["settings"]) do
               add_args({ "-D" .. k .. "=" .. v })
             end
           end
-          if chc["linkage"] ~= nil then
+          if chc["linkage"] ~= nil then -- BUILD_SHARED_LIBS
             local function add_linkage(linkage)
               add_args({ "-DBUILD_SHARED_LIBS=" .. linkage })
             end
@@ -165,7 +184,7 @@ function variants.build_arglist(variant)
             end
           end
           choice_found = true
-          break
+          break -- choice found, break loops
         end
       end
       if choice_found then break end

--- a/lua/simpleyaml.lua
+++ b/lua/simpleyaml.lua
@@ -24,15 +24,19 @@ SOFTWARE.
 
 local simpleyaml = {}
 
+-- parses the YAML file at `path` to a Lua table
+-- returns `nil` in case of error
 function simpleyaml.parse_file(path)
+  -- helper function to apply function `f(data)` at `nestingLevel` of `tab`
   local function atNestingLevel(nestingLevel, f, data, tab)
-    if nestingLevel == 0 then
+    if nestingLevel == 0 then -- arrived at `nestingLevel`, apply `f`
       f(data, tab)
-    else
+    else -- go deeper recursively
       atNestingLevel(nestingLevel - 1, f, data, tab[#tab].val)
     end
   end
 
+  -- helper function to insert a new `key` at `nestingLevel` of `tab`
   local function insertKey(key, nestingLevel, tab)
     atNestingLevel(
       nestingLevel,
@@ -44,52 +48,59 @@ function simpleyaml.parse_file(path)
     )
   end
 
-  local function insertString(str, nestingLevel, table)
+  -- helper function to insert value `str` at `nestingLevel` of `tab`
+  local function insertString(str, nestingLevel, tab)
     atNestingLevel(
       nestingLevel,
       function(s, t)
         t[#t].val = s
       end,
       str,
-      table
+      tab
     )
   end
 
+  -- flatten parsing table by removing indices, so the resulting table can directly be indexed with the YAML keys
   local function flatten(parsed)
     local flattened = {}
-    for _, item in ipairs(parsed) do
-      if type(item.val) ~= "string" then
-        flattened[item.key] = flatten(item.val)
-      else
-        flattened[item.key] = item.val
+    for _, item in ipairs(parsed) do -- for all key-value pairs
+      if type(item.val) ~= "string" then -- if the value is not a string (it's a table)
+        flattened[item.key] = flatten(item.val) -- flatten the table
+      else -- if the value is a string
+        flattened[item.key] = item.val -- just assign it
       end
     end
     return flattened
   end
 
+  -- start parsing
+
+  -- (try to) open YAML file
   local file = io.open(path, "r")
   if not file then
     return nil
   end
 
-  local nestingLevel = 0
-  local indents      = {}
-  local parsed       = {}
+  local nestingLevel = 0 -- current nesting level
+  local indents      = {} -- stack of indents
+  local parsed       = {} -- resulting table
 
-  for line in file:lines() do
-    if line:gsub("%s*", "") == "" or line:find("^#") ~= nil or line:find("^---") ~= nil then
+  for line in file:lines() do -- for all lines in the file
+    -- goto next line if current line is empty, a comment, the document start, or a directive
+    if line:gsub("%s*", "") == "" or line:find("^#") ~= nil or line:find("^---") ~= nil or line:find("^%") ~= nil then
       goto cont_processing_lines
     end
 
-    local indent = line:match("(%s*)%S.*"):len()
-    if #indents > 0 then
+    local indent = line:match("(%s*)%S.*"):len() -- get indent of current line
+    if #indents > 0 then -- if stack of indents not empty
       local prevIndent = indents[#indents]
 
-      if indent > prevIndent then
+      -- compare with indent of previous line
+      if indent > prevIndent then -- if current indent larger, increase nesting level
         nestingLevel = nestingLevel + 1;
-      elseif indent < prevIndent then
+      elseif indent < prevIndent then -- of current indent smaller, decrease nesting level and ...
         nestingLevel = nestingLevel - 1;
-        while indents[#indents] > indent do
+        while indents[#indents] > indent do -- ... clean up the stack of indents, tracking the nesting level
           if prevIndent < indents[#indents] then
             nestingLevel = nestingLevel + 1
           elseif prevIndent > indents[#indents] then
@@ -100,12 +111,17 @@ function simpleyaml.parse_file(path)
         end
       end
     end
-    table.insert(indents, indent)
+    table.insert(indents, indent) -- insert current indent into stack
 
-    local key = line:match("%s*(.*):")
-    insertKey(key, nestingLevel, parsed)
+    local key = line:match("%s*(.*):") -- read the key from the line (everything before ':')
+    if key == "" then -- no key found, error
+      return nil
+    end
+    insertKey(key, nestingLevel, parsed) -- insert the key
 
-    line = line:match(":%s*(.*)%s*")
+    line = line:match(":%s*(.*)%s*") -- read rest of the line (everything after ':')
+    -- if there is something, insert the rest of the line as a string value
+    -- otherwise, the value is an object, so go ahead to read next line
     if line:len() > 0 then
       insertString(line, nestingLevel, parsed)
     end

--- a/lua/simpleyaml.lua
+++ b/lua/simpleyaml.lua
@@ -1,0 +1,121 @@
+--[[
+MIT License
+
+Copyright (c) 2022 Ole Lübke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+--]]
+
+local simpleyaml = {}
+
+function simpleyaml.parse_file(path)
+  local function atNestingLevel(nestingLevel, f, data, tab)
+    if nestingLevel == 0 then
+      f(data, tab)
+    else
+      atNestingLevel(nestingLevel - 1, f, data, tab[#tab].val)
+    end
+  end
+
+  local function insertKey(key, nestingLevel, tab)
+    atNestingLevel(
+      nestingLevel,
+      function(k, t)
+        table.insert(t, { key = k, val = {} })
+      end,
+      key,
+      tab
+    )
+  end
+
+  local function insertString(str, nestingLevel, table)
+    atNestingLevel(
+      nestingLevel,
+      function(s, t)
+        t[#t].val = s
+      end,
+      str,
+      table
+    )
+  end
+
+  local function flatten(parsed)
+    local flattened = {}
+    for _, item in ipairs(parsed) do
+      if type(item.val) ~= "string" then
+        flattened[item.key] = flatten(item.val)
+      else
+        flattened[item.key] = item.val
+      end
+    end
+    return flattened
+  end
+
+  local file = io.open(path, "r")
+  if not file then
+    return nil
+  end
+
+  local nestingLevel = 0
+  local indents      = {}
+  local parsed       = {}
+
+  for line in file:lines() do
+    if line:gsub("%s*", "") == "" or line:find("^#") ~= nil or line:find("^---") ~= nil then
+      goto cont_processing_lines
+    end
+
+    local indent = line:match("(%s*)%S.*"):len()
+    if #indents > 0 then
+      local prevIndent = indents[#indents]
+
+      if indent > prevIndent then
+        nestingLevel = nestingLevel + 1;
+      elseif indent < prevIndent then
+        nestingLevel = nestingLevel - 1;
+        while indents[#indents] > indent do
+          if prevIndent < indents[#indents] then
+            nestingLevel = nestingLevel + 1
+          elseif prevIndent > indents[#indents] then
+            nestingLevel = nestingLevel - 1
+          end
+          prevIndent = indents[#indents]
+          table.remove(indents)
+        end
+      end
+    end
+    table.insert(indents, indent)
+
+    local key = line:match("%s*(.*):")
+    insertKey(key, nestingLevel, parsed)
+
+    line = line:match(":%s*(.*)%s*")
+    if line:len() > 0 then
+      insertString(line, nestingLevel, parsed)
+    end
+
+    ::cont_processing_lines::
+  end
+
+  file:close()
+
+  return flatten(parsed)
+end
+
+return simpleyaml


### PR DESCRIPTION
Adds support for [CMake Variants](https://vector-of-bool.github.io/docs/vscode-cmake-tools/variants.html) from the [CMake Tools for Visual Studio Code](https://github.com/microsoft/vscode-cmake-tools).

It's far from perfect though currently (I'm a Lua beginner and didn't write any comments (yet)).
The YAML parsing is done by [simpleyaml](https://github.com/toolcreator/simpleyaml.lua) which I wrote specifically for this purpose.
At first I couldn't find any simple, dependency-free YAML parsing library. Then I found there are some options on github, but I was already done with my own implementation.
It does only parse well-formed files, probably only parses a subset of YAML, and doesn't have any error handling, so maybe it should be exchanged for something more robust.

A thing I added for this to work more fluently is, that CMakeSelectBuildType deletes the build directory if the chosen build type changes. This way it's quicker to change between build types.

variants.lua contains some CC-BY-SA licensed code from [rosettacode.org](https://rosettacode.org/wiki/Rosetta_Code), but that's [compatible with GPLv3](https://creativecommons.org/share-your-work/licensing-considerations/compatible-licenses/).

I'm dropping this here as an idea. If you're interested in integrating the feature we could discuss if we should change anything before merging.
Otherwise I may just keep it as is for my own use.