### PR TITLE
Fix bug where search for cmake-variants would crash if none present

### DIFF
--- a/lua/cmake-tools/variants.lua
+++ b/lua/cmake-tools/variants.lua
@@ -13,18 +13,11 @@ local function parse()
   local function findcfg()
     local files = vim.fn.readdir(".")
     local file = nil
-    local dir = ".."
-    while files and not file do -- iterate over files in current directory
-      for _, f in ipairs(files) do
-        if f == "cmake-variants.yaml" or f == "cmake-variants.json" then -- if a variants config file is found
-          dir = dir:match("%.%./((%.%./)*)") -- constructi its full path and break the loop
-          if not dir then dir = "./" end
-          file = vim.fn.resolve(dir .. f)
-          break
-        end
+    for _, f in ipairs(files) do -- iterate over files in current directory
+      if f == "cmake-variants.yaml" or f == "cmake-variants.json" then -- if a variants config file is found
+        file = vim.fn.resolve("./" .. f)
+        break
       end
-      files = vim.fn.readdir(dir)
-      dir = dir .. "/.."
     end
 
     return file


### PR DESCRIPTION
I found the issue you mentioned [here](https://github.com/Civitasv/cmake-tools.nvim/issues/6#issuecomment-1297341842).

The search for the cmake-variants file would ultimately result in a crash, because if no file is found in the current directory, it goes up directories until it finds a suitably named file or crashes and returns the long "../../../" path.

To solve that, I restricted the search to just the current directory.