### PR TITLE
hot-fix:configration not work

### DIFF
--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -20,26 +20,14 @@ function Config:new()
   local obj = {}
   setmetatable(obj, self)
   self.__index = self
-  self.build_directory = Path:new(vim.loop.cwd(), const.cmake_build_directory)
-  self.query_directory = Path:new(
-    vim.loop.cwd(),
-    const.cmake_build_directory,
-    ".cmake",
-    "api",
-    "v1",
-    "query"
-  )
-  self.reply_directory = Path:new(
-    vim.loop.cwd(),
-    const.cmake_build_directory,
-    ".cmake",
-    "api",
-    "v1",
-    "reply"
-  )
-  self.build_type = const.cmake_build_type
-  self.generate_options = const.cmake_generate_options
-  self.build_options = const.cmake_build_options
+  self.build_directory = Path:new(vim.loop.cwd(), const.options.cmake_build_directory)
+  self.query_directory =
+    Path:new(vim.loop.cwd(), const.options.cmake_build_directory, ".cmake", "api", "v1", "query")
+  self.reply_directory =
+    Path:new(vim.loop.cwd(), const.options.cmake_build_directory, ".cmake", "api", "v1", "reply")
+  self.build_type = const.options.cmake_build_type
+  self.generate_options = const.options.cmake_generate_options
+  self.build_options = const.options.cmake_build_options
 
   return self
 end
@@ -50,10 +38,8 @@ function Config:get_codemodel_targets()
     return Result:new(Types.NOT_CONFIGURED, nil, "Configure fail")
   end
 
-  local found_files = scandir.scan_dir(
-    self.reply_directory.filename,
-    { search_pattern = "codemodel*" }
-  )
+  local found_files =
+    scandir.scan_dir(self.reply_directory.filename, { search_pattern = "codemodel*" })
   if #found_files == 0 then
     return Result:new(Types.CANNOT_FIND_CODEMODEL_FILE, nil, "Unable to find codemodel file")
   end

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -1,4 +1,4 @@
-local const = {
+local defaults = {
   cmake_command = "cmake",
   cmake_build_directory = "build",
   cmake_build_type = "Debug",
@@ -12,8 +12,17 @@ local const = {
   cmake_dap_open_command = require("dap").repl.open,
   cmake_variants_message = {
     short = { show = true },
-    long = { show = true, max_length = 40 }
-  }
+    long = { show = true, max_length = 40 },
+  },
 }
 
-return const
+local M = {}
+M.options = {}
+
+function M.setup(options)
+  M.options = vim.tbl_deep_extend("force", {}, defaults, options or {})
+end
+
+M.setup()
+
+return M

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -37,7 +37,7 @@ function utils.dump(o)
 end
 
 function utils.show_cmake_console()
-  vim.api.nvim_command("copen " .. const.cmake_console_size)
+  vim.api.nvim_command("copen " .. const.options.cmake_console_size)
   vim.api.nvim_command("wincmd j")
 end
 
@@ -57,7 +57,11 @@ end
 function utils.execute(executable, opts)
   -- print("EXECUTABLE", executable)
   local set_bufname = "file " .. opts.bufname
-  local prefix = string.format("%s %d new", const.cmake_console_position, const.cmake_console_size)
+  local prefix = string.format(
+    "%s %d new",
+    const.options.cmake_console_position,
+    const.options.cmake_console_size
+  )
 
   vim.api.nvim_command("cclose")
   vim.cmd(prefix .. " | term " .. executable)
@@ -92,7 +96,7 @@ end
 -- Execute CMake command using job api
 function utils.run(cmd, args, opts)
   vim.fn.setqflist({}, " ", { title = cmd .. " " .. table.concat(args, " ") })
-  opts.cmake_show_console = const.cmake_show_console == "always"
+  opts.cmake_show_console = const.options.cmake_show_console == "always"
   if opts.cmake_show_console then
     utils.show_cmake_console()
   end
@@ -128,8 +132,8 @@ function utils.has_active_job()
   end
   utils.error(
     "A CMake task is already running: "
-    .. utils.job.command
-    .. " Stop it before trying to run a new CMake task."
+      .. utils.job.command
+      .. " Stop it before trying to run a new CMake task."
   )
   return false
 end


### PR DESCRIPTION
Some configuration do not work. Eg. `cmake_console_size` ..
Because `utils.lua` and `config.lua` cannot properly load `const` variables that are changed by the `require("cmake-tools").setup()` in the neovim configuration