### PR TITLE
fix presets usage

### DIFF
--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -14,7 +14,8 @@ local Config = {
   build_type = nil,
   build_target = nil,
   launch_target = nil,
-  cmake_kit = nil
+  cmake_kit = nil,
+  preset = nil,
 }
 
 function Config:new(const)

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -22,4 +22,13 @@ function presets.check()
   return file
 end
 
+function presets.parsePresets(file, presetType)
+  local data = vim.fn.json_decode(vim.fn.readfile(file))
+  local options = {}
+  for _, v in pairs(data[presetType]) do
+    table.insert(options, v["name"])
+  end
+  return options
+end
+
 return presets


### PR DESCRIPTION
New:
- `presets.lua`: I created a function that will parse CMakePresets.json and retrieve their name, since preset you need to pass the name, not the file
- `config.lua`: ah new nil parameter for preset value

Changes:
-`init.lua` - removed references for preset inside `clean`, since it doesn't really help with anything there,
-`init.lua` - changed how to select preset using `vim.ui.select` in `generate` and `build` functions, also I reordered the parameters since it's important to preset comes first than the others.
