### PR TITLE
dap start up error

### DIFF
--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -1,3 +1,11 @@
+local has_dap, dap = pcall(require, "dap")
+local dap_repl_open = nil
+
+if has_dap
+then
+  dap_repl_open = dap.repl.open
+end
+
 local const = {
   cmake_command = "/usr/bin/cmake",
   cmake_build_directory = "build",
@@ -8,7 +16,7 @@ local const = {
   cmake_show_console = "always", -- "always", "only_on_error"
   cmake_focus_on_console = false, -- true, false
   cmake_dap_configuration = { name = "cpp", type = "codelldb", request = "launch" },
-  cmake_dap_open_command = require("dap").repl.open,
+  cmake_dap_open_command = dap_repl_open,
   cmake_variants_message = {
     short = { show = true },
     long = { show = true, max_length = 40 }


### PR DESCRIPTION
If dap is not installed on start up you will get an error even if optional dap command is set to nil. Check in const.lua if dap is available before using it.

Here is the error 
```
Error detected while processing /nvim/site/pack/packer/start/cmake-tools.nvim/plugin/cmake-tools.lua:
E5113: Error while calling lua chunk: .../packer/start/cmake-tools.nvim/lua/cmake-tools/const.lua:11:  module 'dap' not found: 
        no field package.preload['dap']
        no file './dap.lua'
        no file '/usr/share/luajit-2.1.0-beta3/dap.lua'
        no file '/usr/local/share/lua/5.1/dap.lua'
        no file '/usr/local/share/lua/5.1/dap/init.lua'
        no file '/usr/share/lua/5.1/dap.lua'
        no file '/usr/share/lua/5.1/dap/init.lua'
        no file '/nvim/.cache/nvim/packer_hererocks/2.1.0-beta3/share/lua/5.1/dap.lua'
        no file '/nvim/.cache/nvim/packer_hererocks/2.1.0-beta3/share/lua/5.1/dap/init.lua'
        no file '/nvim/.cache/nvim/packer_hererocks/2.1.0-beta3/lib/luarocks/rocks-5.1/dap.lua'
        no file '/nvim/.cache/nvim/packer_hererocks/2.1.0-beta3/lib/luarocks/rocks-5.1/dap/init.lua'
        no file './dap.so'
        no file '/usr/local/lib/lua/5.1/dap.so'
        no file '/usr/lib/x86_64-linux-gnu/lua/5.1/dap.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
        no file '/home/nash/.cache/nvim/packer_hererocks/2.1.0-beta3/lib/lua/5.1/dap.so'
stack traceback:
            [C]: in function 'require'
            .../packer/start/cmake-tools.nvim/lua/cmake-tools/const.lua:11: in main chunk
            [C]: in function 'require'
             ...k/packer/start/cmake-tools.nvim/lua/cmake-tools/init.lua:5: in main chunk
            [C]: in function 'require'
            ...ack/packer/start/cmake-tools.nvim/plugin/cmake-tools.lua:4: in main chunk
```