### PR TITLE
Handle includes in the top level presets file

### DIFF
--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -39,6 +39,9 @@ end
 -- Decodes a Cmake[User]Presets.json and its "includes", if any
 local function decode(file)
   local data = vim.fn.json_decode(vim.fn.readfile(file))
+  if not data then
+    error(string.format('Could not parse %s', file))
+  end
   local includes = data['include']
   if not includes then
     return data
@@ -184,7 +187,11 @@ function presets.get_build_dir(preset)
   local source_path = Path:new(vim.loop.cwd())
   local source_relative = vim.fn.fnamemodify(vim.loop.cwd(), ":t")
 
-  build_dir = build_dir:gsub("${sourceDir}", vim.loop.cwd())
+  local cwd = vim.loop.cwd()
+  if not cwd then
+    cwd = "."
+  end
+  build_dir = build_dir:gsub("${sourceDir}", cwd)
   build_dir = build_dir:gsub("${sourceParentDir}", source_path:parent().filename)
   build_dir = build_dir:gsub("${sourceDirName}", source_relative)
   build_dir = build_dir:gsub("${presetName}", preset.name)

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -28,7 +28,7 @@ end
 -- key is [key] and the value is the resulting list table of merging
 -- dst[key] and src[key].
 -- This function mutates dest.
-local function mergeTableListByKey(dst, src, key)
+local function merge_table_list_by_key(dst, src, key)
   if not dst[key] then
     dst[key]={}
   end
@@ -55,7 +55,7 @@ local function decode(file)
                                            vim.tbl_keys(fdata))
 
     for _, eachPreset in ipairs(thisFilePresetKeys) do
-      mergeTableListByKey(data, fdata,eachPreset )
+      merge_table_list_by_key(data, fdata, eachPreset)
     end
   end
 

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -24,6 +24,41 @@ function presets.check()
   return file
 end
 
+-- Extends (or creates a new) key-value pair in [dest] in which the
+-- key is [key] and the value is the resulting list table of merging
+-- dst[key] and src[key].
+-- This function mutates dest.
+local function mergeTableListByKey(dst, src, key)
+  if not dst[key] then
+    dst[key]={}
+  end
+  vim.list_extend(dst[key], src[key])
+end
+
+
+-- Decodes a Cmake[User]Presets.json and its "includes", if any
+local function decode(file)
+  local data = vim.fn.json_decode(vim.fn.readfile(file))
+  local includes = data['include']
+  if not includes then
+    return data
+  end
+
+  for _, f in ipairs(includes) do
+    local fdata = vim.fn.json_decode(vim.fn.readfile(f))
+    local thisFilePresetKeys = vim.tbl_filter(function(key)
+                                                return string.find(key, "Presets")
+                                              end,
+                                           vim.tbl_keys(fdata))
+
+    for _, eachPreset in ipairs(thisFilePresetKeys) do
+      mergeTableListByKey(data, fdata,eachPreset )
+    end
+  end
+
+  return data
+end
+
 -- Retrieve all presets with type
 -- @param type: `buildPresets` or `configurePresets`
 -- @param {opts}: include_hidden(bool|nil).
@@ -36,7 +71,10 @@ function presets.parse(type, opts)
     return options
   end
   local include_hidden = opts and opts.include_hidden
-  local data = vim.fn.json_decode(vim.fn.readfile(file))
+  local data = decode(file)
+  if not data then
+    error("Error when parsing the presets file")
+  end
   for _, v in pairs(data[type]) do
     if include_hidden or not v["hidden"] then
       table.insert(options, v["name"])
@@ -57,7 +95,10 @@ function presets.parse_name_mapped(type, opts)
     return options
   end
   local include_hidden = opts and opts.include_hidden
-  local data = vim.fn.json_decode(vim.fn.readfile(file))
+  local data = decode(file)
+  if not data then
+    error("Error when parsing the presets file")
+  end
   for _, v in pairs(data[type]) do
     if include_hidden or not v["hidden"] then
       options[v["name"]] = v
@@ -74,7 +115,7 @@ function presets.get_preset_by_name(name, type)
   if not file then
     return nil
   end
-  local data = vim.fn.json_decode(vim.fn.readfile(file))
+  local data = decode(file)
   for _, v in pairs(data[type]) do
     if v.name == name then
       return v


### PR DESCRIPTION
Here is a suggestion to partially tackle #30 .

The proposed changes follow the files included in the top level `CMake[User]Presets.json` file, decodes them and merge their presets into the table that will be later used when the plugin checks for presets.

Thank you for the awesome plugin!