### PR TITLE
Update init.lua

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -305,7 +305,7 @@ function cmake.run(opt, callback)
         local target_path = result.data
         -- print("TARGET", target_path)
 
-        return utils.execute(target_path, {
+        return utils.execute('"' .. target_path .. '"', {
           bufname = vim.fn.expand("%:t:r"),
           cmake_console_position = const.cmake_console_position,
           cmake_console_size = const.cmake_console_size


### PR DESCRIPTION
Wrapped the variable target_path in quotes in cmake.run(), so that the executable could run even if its path contains spaces.