### PR TITLE
W.I.P: Multi compiler, generator, architecture support for Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,22 +118,151 @@ When using multiple compilers, you can specify this in your `CMakeKits.json` or 
 
 ```json
 [
-	{
-		"name": "Clang_14.0.6_x86_64-w64-windows-gnu",
-		"compilers": {
-			"C": "path/to/C/Compiler",
-			"CXX": "path/to/CXX/Compiler"
-		}
-	},
-	{
-		"name": "Clang_15.0.7_x86_64-pc-windows-msvc",
-		"compilers": {
-			"C": "path/to/C/Compiler",
-			"CXX": "path/to/CXX/Compiler"
-		}
+  {
+    "name": "Clang_14.0.6_x86_64-w64-windows-gnu",
+	"compilers": {
+      "C": "path/to/C/Compiler",
+      "CXX": "path/to/CXX/Compiler"
 	}
+  },
+  {
+	"name": "Clang_15.0.7_x86_64-pc-windows-msvc",
+	"compilers": {
+	  "C": "path/to/C/Compiler",
+      "CXX": "path/to/CXX/Compiler"
+	}
+  }
 ]
 ```
+
+## MSVC Support without kit scans
+
+Currently, we do not have an implementation of `vswhere` in lua for MSVC kit scanning, however, architectures and hosts can be set as:
+
+```json
+{
+  "name": "VS 17 2022 amd64",
+  "generator": "Visual Studio 17 2022",
+  "host_architecture": "x64",
+  "target_architecture": "x64",
+  "compilers": {
+    "C": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe",
+    "CXX": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin//Hostx64/x64/cl.exe"
+    }
+},
+
+```
+
+Here is the MSVC config in their standard location within `Program Files` and `Program Files (x86)`. Tweaks to the compiler location might be necessary if installation locations are different. This is a workaround for till auto scanning is implemented.
+
+<details>
+<Summary>All MSVC Configs<\Summary>
+
+```json
+{
+  "name": "VS 16 2019 amd64",
+  "generator": "Visual Studio 16 2019",
+  "host_architecture": "x64",
+  "target_architecture": "x64",
+  "compilers": {
+    "C": "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/Hostx64/x64/cl.exe",
+    "CXX": "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe"
+    }
+},
+{
+  "name": "VS 16 2019 amd64_x86",
+  "generator": "Visual Studio 16 2019",
+  "host_architecture": "x64",
+  "target_architecture": "win32",
+  "compilers": {
+    "C": "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/Hostx64/x86/cl.exe",
+    "CXX": "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x86/cl.exe"
+    }
+},
+{
+  "name": "VS 16 2019 x86",
+  "generator": "Visual Studio 16 2019",
+  "host_architecture": "x86",
+  "target_architecture": "win32",
+  "compilers": {
+    "C": "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx86/x86/cl.exe",
+    "CXX": "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx86/x86/cl.exe"
+    }
+},
+{
+  "name": "VS 16 2019 x86_amd64",
+  "generator": "Visual Studio 16 2019",
+  "host_architecture": "x86",
+  "target_architecture": "x64",
+  "compilers": {
+    "C": "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx86/x64/cl.exe",
+    "CXX": "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx86/x64/cl.exe"
+    }
+},
+{
+  "name": "VS 17 2022 amd64",
+  "generator": "Visual Studio 17 2022",
+  "host_architecture": "x64",
+  "target_architecture": "x64",
+  "compilers": {
+    "C": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe",
+    "CXX": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin//Hostx64/x64/cl.exe"
+    }
+},
+{
+  "name": "VS 17 2022 amd64_arm64",
+  "generator": "Visual Studio 17 2022",
+  "host_architecture": "x64",
+  "target_architecture": "arm64",
+  "compilers": {
+    "C": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x86/cl.exe",
+    "CXX": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x86/cl.exe"
+    }
+},
+{
+  "name": "VS 17 2022 amd64_x86",
+  "generator": "Visual Studio 17 2022",
+  "host_architecture": "x64",
+  "target_architecture": "win32",
+  "compilers": {
+    "C": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/arm64/cl.exe",
+    "CXX": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/arm64/cl.exe"
+    }
+},
+{
+  "name": "VS 17 2022 x86",
+  "generator": "Visual Studio 17 2022",
+  "host_architecture": "x86",
+  "target_architecture": "win32",
+  "compilers": {
+    "C": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx86/x86/cl.exe",
+    "CXX": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx86/x86/cl.exe"
+    }
+},
+{
+  "name": "VS 17 2022 x86_amd64",
+  "generator": "Visual Studio 17 2022",
+  "host_architecture": "x86",
+  "target_architecture": "x64",
+  "compilers": {
+    "C": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx86/x64/cl.exe",
+    "CXX": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx86/x64/cl.exe"
+    }
+},
+{
+  "name": "VS 17 2022 x86_arm64",
+  "generator": "Visual Studio 17 2022",
+  "host_architecture": "x86",
+  "target_architecture": "arm64",
+  "compilers": {
+    "C": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx86/arm64/cl.exe",
+    "CXX": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx86/arm64/cl.exe"
+    }
+}
+
+```
+
+<\details>
 
 ## How to make cmake-tools work exactly like it in exmaple video?
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,103 @@ Here is the MSVC config in their standard location within `Program Files` and `P
 
 <\details>
 
+## Windows : MinGw / GCC / Clang / Clang-cl support
+
+Exmaples of clang, gcc, clang-cl, and gcc support in windows. **You must specify the generator.** For example:
+
+```json
+{
+  "name": "Clang_14.0.6_x86_64-w64-windows-gnu",
+  "generator":"Ninja",
+  "compilers": {
+    "C": "C:/mingw64/bin/clang.exe",
+    "CXX": "C:/mingw64/bin/clang++.exe"
+  }
+},
+{
+  "name": "GCC_12.2.0_15.0.7_x86_64-windows-msvc",
+  "generator":"MinGW Makefiles",
+  "compilers": {
+    "C": "C:/mingw64/bin/gcc.exe",
+    "CXX": "C:/mingw64/bin/g++.exe"
+  }
+}
+
+```
+
+<details>
+<Summary>More Examples<\Summary>
+
+```json
+{
+  "name": "Clang_14.0.6_x86_64-w64-windows-gnu",
+  "generator":"Ninja",
+  "compilers": {
+    "C": "C:/mingw64/bin/clang.exe",
+    "CXX": "C:/mingw64/bin/clang++.exe"
+ }
+},
+{
+  "name": "Clang-cl 14.0.6 x86_64-pc-windows-msvc",
+  "generator":"Ninja",
+  "compilers": {
+    "C": "C:/mingw64/bin/clang-cl.exe",
+    "CXX": "C:/mingw64/bin/clang-cl.exe"
+  }
+},
+{
+  "name": "Clang_15.0.7_x86_64-pc-windows-msvc",
+  "generator":"Ninja",
+  "compilers": {
+    "C": "C:/Program Files/LLVM/bin/clang.exe",
+    "CXX": "C:/Program Files/LLVM/bin/clang++.exe"
+  }
+},
+{
+  "name": "Clang_cl_15.0.7_x86_64-pc-windows-msvc",
+  "generator":"Ninja",
+  "compilers": {
+    "C": "C:/Program Files/LLVM/bin/clang-cl.exe",
+    "CXX": "C:/Program Files/LLVM/bin/clang-cl.exe"
+  }
+},
+{
+  "name": "GCC_12.2.0_15.0.7_x86_64-windows-msvc",
+  "generator":"MinGW Makefiles",
+  "compilers": {
+    "C": "C:/mingw64/bin/gcc.exe",
+    "CXX": "C:/mingw64/bin/g++.exe"
+  }
+},
+{
+  "name": "GCC_6.3.0_mingw32",
+  "generator":"Ninja",
+  "compilers": {
+    "C": "C:/MinGW/bin/mingw32-gcc.exe",
+    "CXX": "C:/MinGW/bin/mingw32-g++.exe"
+  }
+},
+{
+  "name": "GCC_8.3.0_x86_64-mingw32",
+  "generator":"Ninja",
+  "compilers": {
+    "C": "C:/Strawberry/c/bin/gcc.exe",
+    "CXX": "C:/Strawberry/c/bin/g++.exe"
+  }
+},
+{
+  "name": "GCC_9.2.0_x86_64-mingw32",
+  "generator":"Ninja",
+  "compilers": {
+    "C": "C:/MinGW/bin/gcc.exe",
+    "CXX": "C:/MinGW/bin/g++.exe"
+  }
+},
+
+```
+
+<\details>
+
 ## How to make cmake-tools work exactly like it in exmaple video?
 
 ### lualine

--- a/README.md
+++ b/README.md
@@ -112,6 +112,29 @@ The option `cmake_build_directory_prefix` will be activated only when `cmake_bui
 
 See detailed user scenario from issue [#21](https://github.com/Civitasv/cmake-tools.nvim/issues/21).
 
+## Using Multiple compilers
+
+When using multiple compilers, you can specify this in your `CMakeKits.json` or `cmake-kits.json` file in your root directory. (See the Lualine config below to select the different comiplers from the GUI)
+
+```json
+[
+	{
+		"name": "Clang_14.0.6_x86_64-w64-windows-gnu",
+		"compilers": {
+			"C": "path/to/C/Compiler",
+			"CXX": "path/to/CXX/Compiler"
+		}
+	},
+	{
+		"name": "Clang_15.0.7_x86_64-pc-windows-msvc",
+		"compilers": {
+			"C": "path/to/C/Compiler",
+			"CXX": "path/to/CXX/Compiler"
+		}
+	}
+]
+```
+
 ## How to make cmake-tools work exactly like it in exmaple video?
 
 ### lualine

--- a/README.md
+++ b/README.md
@@ -153,10 +153,12 @@ Currently, we do not have an implementation of `vswhere` in lua for MSVC kit sca
 
 ```
 
-Here is the MSVC config in their standard location within `Program Files` and `Program Files (x86)`. Tweaks to the compiler location might be necessary if installation locations are different. This is a workaround for till auto scanning is implemented.
+Here is the MSVC config in their standard location within `Program Files` and `Program Files (x86)`. **Tweaks to the compiler location might be necessary** if installation locations are different from what is shown below. This is a workaround for till auto kit scanning is implemented.
+
+### All MSVC Config Examples
 
 <details>
-<Summary>All MSVC Configs<\Summary>
+<Summary>Click to expand MSVC Configs</Summary>
 
 ```json
 {
@@ -262,7 +264,7 @@ Here is the MSVC config in their standard location within `Program Files` and `P
 
 ```
 
-<\details>
+</details>
 
 ## Windows : MinGw / GCC / Clang / Clang-cl support
 
@@ -287,9 +289,10 @@ Exmaples of clang, gcc, clang-cl, and gcc support in windows. **You must specify
 }
 
 ```
+### MinGW/Ninja/GCC/Clang/Clang-cl Examples
 
 <details>
-<Summary>More Examples<\Summary>
+<Summary>Click to expand Examples</Summary>
 
 ```json
 {
@@ -359,7 +362,7 @@ Exmaples of clang, gcc, clang-cl, and gcc support in windows. **You must specify
 
 ```
 
-<\details>
+</details>
 
 ## How to make cmake-tools work exactly like it in exmaple video?
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Example:
 ```json
 {
   "name": "My Compiler Kit",
+  
+  <!-- For windows if CMakeKits are used as there are default msvc compilers. Ignore if CMakeUserPrests are used. -->
+  "generator":"Ninja", 
+  
   "compilers": {
     "C": "/usr/bin/gcc",
     "CXX": "/usr/bin/g++",
@@ -120,24 +124,36 @@ When using multiple compilers, you can specify this in your `CMakeKits.json` or 
 [
   {
     "name": "Clang_14.0.6_x86_64-w64-windows-gnu",
-	"compilers": {
+    "generator":"Ninja",
+    "compilers": {
       "C": "path/to/C/Compiler",
       "CXX": "path/to/CXX/Compiler"
-	}
+    }
   },
   {
-	"name": "Clang_15.0.7_x86_64-pc-windows-msvc",
-	"compilers": {
-	  "C": "path/to/C/Compiler",
+    "name": "Clang_15.0.7_x86_64-pc-windows-msvc",
+    "generator":"Ninja",
+    "compilers": {
+      "C": "path/to/C/Compiler",
       "CXX": "path/to/CXX/Compiler"
-	}
-  }
+    }
+  },
+  {
+    "name": "VS 17 2022 amd64",
+    "generator": "Visual Studio 17 2022",
+    "host_architecture": "x64",
+    "target_architecture": "x64",
+    "compilers": {
+      "C": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe",
+      "CXX": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin//Hostx64/x64/cl.exe"
+    }
+  },
 ]
 ```
 
 ## MSVC Support without kit scans
 
-Currently, we do not have an implementation of `vswhere` in lua for MSVC kit scanning, however, architectures and hosts can be set as:
+Currently, we do not have an implementation of `vswhere` in lua for kit scanning. However, architectures and hosts and generators can be set as:
 
 ```json
 {
@@ -153,9 +169,9 @@ Currently, we do not have an implementation of `vswhere` in lua for MSVC kit sca
 
 ```
 
-Here is the MSVC config in their standard location within `Program Files` and `Program Files (x86)`. **Tweaks to the compiler location might be necessary** if installation locations are different from what is shown below. This is a workaround for till auto kit scanning is implemented.
+For MSVC config in their standard location within `Program Files` and `Program Files (x86)`. This is a workaround for till auto kit scanning is implemented. (**Tweaks to the compiler location might be necessary** if installation locations are different from what is shown below.)
 
-### All MSVC Config Examples
+All MSVC Config Examples:
 
 <details>
 <Summary>Click to expand MSVC Configs</Summary>
@@ -289,10 +305,10 @@ Exmaples of clang, gcc, clang-cl, and gcc support in windows. **You must specify
 }
 
 ```
-### MinGW/Ninja/GCC/Clang/Clang-cl Examples
+More MinGW/Ninja/GCC/Clang/Clang-cl Examples
 
 <details>
-<Summary>Click to expand Examples</Summary>
+<Summary>Click to expand More Examples</Summary>
 
 ```json
 {
@@ -792,11 +808,10 @@ telescope.load_extension("ui-select")
 
 ### CMake Kit
 
-0. Support Kits scan.
-1. Support Visual Studio.
-2. Support option `preferredGenerator`.
-3. Support option `cmakeSettings`.
-4. Support option `environmentSetupScript`.
+0. Support Kits scan. <!-- 1. Support Visual Studio. -->
+1. Support option `preferredGenerator`.
+2. Support option `cmakeSettings`.
+3. Support option `environmentSetupScript`.
 
 ### Others
 

--- a/lua/cmake-tools/kits.lua
+++ b/lua/cmake-tools/kits.lua
@@ -84,7 +84,7 @@ function kits.build_env_and_args(kit_name)
   -- if exists `compilers` option, then set variable for cmake
   if kit.compilers then
     for lang, compiler in pairs(kit.compilers) do
-      add_args({ "-DCMAKE_" .. lang .. "_COMPILER=" .. compiler })
+      add_args({ "-DCMAKE_" .. lang .. "_COMPILER:FILEPATH=" .. compiler })
     end
   end
   if kit.generator then
@@ -97,7 +97,7 @@ function kits.build_env_and_args(kit_name)
       table.insert(args, "-A " .. kit.target_architecture)
   end
   if kit.toolchainFile then
-    add_args({ "-DCMAKE_TOOLCHAIN_FILE=" .. kit.toolchainFile })
+    add_args({ "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=" .. kit.toolchainFile })
   end
 
   if kit.environmentVariables then

--- a/lua/cmake-tools/kits.lua
+++ b/lua/cmake-tools/kits.lua
@@ -87,6 +87,15 @@ function kits.build_env_and_args(kit_name)
       add_args({ "-DCMAKE_" .. lang .. "_COMPILER=" .. compiler })
     end
   end
+  if kit.generator then
+      table.insert(args, "-G " .. kit.generator)
+  end
+  if kit.host_architecture then
+      table.insert(args, "-T host=" .. kit.host_architecture)
+  end
+  if kit.target_architecture then
+      table.insert(args, "-A " .. kit.target_architecture)
+  end
   if kit.toolchainFile then
     add_args({ "-DCMAKE_TOOLCHAIN_FILE=" .. kit.toolchainFile })
   end

--- a/lua/cmake-tools/variants.lua
+++ b/lua/cmake-tools/variants.lua
@@ -196,7 +196,7 @@ function variants.build_arglist(variant)
   --[[ print("VARIANT", utils.dump(variant)) ]]
   -- helper function to build a simple command line option that defines the CMAKE_BUILD_TYPE variable to `build_type`
   local function build_simple(build_type)
-    return { "-D", "CMAKE_BUILD_TYPE=" .. build_type }
+    return { "-D", "CMAKE_BUILD_TYPE:STRING=" .. build_type }
   end
 
   -- start building arglist


### PR DESCRIPTION
# Testing in Progress: MSVC Support (WIP)

* Added Temporary MSVC Support with examples until kit scan is implemented.
* Added Generator Support
* Added Host Architecture Support
* Added Target Architecture Support

## Caveats with MSVC (W.I.P)
- [x] Generator options are requried, as behavior defaults to `MSBUILD` instead of `GNU` / `GCC` even when GNU compiler is specified.
- [x] Cross compilation tested: `arm64`, `amd64`, `x86` for MSVC (similar options as in README)
- [x] Auto detects architecture if architecture is not specified.

## Caveats with WSL (W.I.P)
- [x] WSL does not fail when project is configured without any `CMakeKits.json`. So, probably not a breaking change. :D
- [x] Option of generator not tested in wsl
- [x] Not tested with a `CMakekits.json` (Hoping somebody can test this well with linux/wsl)

@Civitasv, can you test this on linux?