### PR TITLE
Add hooks for clangd and ccls to get compile command directory from preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ require("cmake-tools").setup {
   cmake_build_directory = "",
   cmake_build_directory_prefix = "cmake_build_", -- when cmake_build_directory is "", this option will be activated
   cmake_generate_options = { "-D", "CMAKE_EXPORT_COMPILE_COMMANDS=1" },
-  cmake_soft_link_compile_commands = false, -- if softlink compile commands json file
+  cmake_soft_link_compile_commands = true, -- if softlink compile commands json file
   cmake_build_options = {},
   cmake_console_size = 10, -- cmake output window height
   cmake_console_position = "belowright", -- "belowright", "aboveleft", ...

--- a/README.md
+++ b/README.md
@@ -381,6 +381,22 @@ More MinGW/Ninja/GCC/Clang/Clang-cl Examples
 
 </details>
 
+## Automatically setting your compile_commands.json directory
+
+If you're using clangd or ccls configured through [lspconfig](https://github.com/neovim/nvim-lspconfig) you can
+set your compilation database directory to your active preset build directory by calling a hook in your on_new_config callback.
+
+```lua
+require('lspconfig').clangd.setup{
+    on_new_config = function(new_config, new_cwd)
+        local status, cmake = pcall(require, "cmake-tools")
+        if status then
+            cmake.clangd_on_new_config(new_config)
+        end
+    end,
+}
+```
+
 ## How to make cmake-tools work exactly like it in exmaple video?
 
 ### lualine

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ require("cmake-tools").setup {
   cmake_build_directory = "",
   cmake_build_directory_prefix = "cmake_build_", -- when cmake_build_directory is "", this option will be activated
   cmake_generate_options = { "-D", "CMAKE_EXPORT_COMPILE_COMMANDS=1" },
-  cmake_soft_link_compile_commands = true, -- if softlink compile commands json file
+  cmake_soft_link_compile_commands = false, -- if softlink compile commands json file
   cmake_build_options = {},
   cmake_console_size = 10, -- cmake output window height
   cmake_console_position = "belowright", -- "belowright", "aboveleft", ...

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -25,6 +25,7 @@ function Config:new(const)
   self.__index = self
   self.generate_options = const.cmake_generate_options
   self.build_options = const.cmake_build_options
+  self.soft_link_compile_commands = const.cmake_soft_link_compile_commands
 
   return self
 end

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -25,7 +25,6 @@ function Config:new(const)
   self.__index = self
   self.generate_options = const.cmake_generate_options
   self.build_options = const.cmake_build_options
-  self.soft_link_compile_commands = const.cmake_soft_link_compile_commands
 
   return self
 end

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -3,11 +3,12 @@ local const = {
   cmake_build_directory_prefix = "cmake_build_",                    -- when cmake_build_directory is "", this option will be activated
   cmake_command = "cmake",                                          -- cmake command path
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- it will be activated when invoke `cmake.generate`
-  cmake_soft_link_compile_commands = false,
-  cmake_build_options = {},                                         -- it will be activated when invoke `cmake.build`
-  cmake_console_position = "belowright",                            -- "bottom", "top"
+  cmake_soft_link_compile_commands = true,
+  cmake_compile_commands_from_preset = false,
+  cmake_build_options = {},              -- it will be activated when invoke `cmake.build`
+  cmake_console_position = "belowright", -- "bottom", "top"
   cmake_console_size = 10,
-  cmake_show_console = "always",                                    -- "always", "only_on_error"
+  cmake_show_console = "always",         -- "always", "only_on_error"
   cmake_variants_message = {
     short = { show = true },
     long = { show = true, max_length = 40 }

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -1,9 +1,9 @@
 local const = {
-  cmake_build_directory = "", -- cmake generate directory
-  cmake_build_directory_prefix = "cmake_build_", -- when cmake_build_directory is "", this option will be activated
+  cmake_build_directory = "",                                       -- cmake generate directory
+  cmake_build_directory_prefix = "cmake_build_",                    -- when cmake_build_directory is "", this option will be activated
   cmake_command = "cmake",                                          -- cmake command path
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- it will be activated when invoke `cmake.generate`
-  cmake_soft_link_compile_commands = true,
+  cmake_soft_link_compile_commands = false,
   cmake_build_options = {},                                         -- it will be activated when invoke `cmake.build`
   cmake_console_position = "belowright",                            -- "bottom", "top"
   cmake_console_size = 10,

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -1,13 +1,13 @@
 local const = {
-  cmake_command = "/usr/bin/cmake", -- cmake command path
   cmake_build_directory = "", -- cmake generate directory
   cmake_build_directory_prefix = "cmake_build_", -- when cmake_build_directory is "", this option will be activated
+  cmake_command = "cmake",                                          -- cmake command path
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- it will be activated when invoke `cmake.generate`
   cmake_soft_link_compile_commands = true,
-  cmake_build_options = {}, -- it will be activated when invoke `cmake.build`
-  cmake_console_position = "belowright", -- "bottom", "top"
+  cmake_build_options = {},                                         -- it will be activated when invoke `cmake.build`
+  cmake_console_position = "belowright",                            -- "bottom", "top"
   cmake_console_size = 10,
-  cmake_show_console = "always", -- "always", "only_on_error"
+  cmake_show_console = "always",                                    -- "always", "only_on_error"
   cmake_variants_message = {
     short = { show = true },
     long = { show = true, max_length = 40 }

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -639,8 +639,8 @@ function cmake.has_cmake_preset()
 end
 
 function cmake.configure_compile_commands()
-  if config.lsp_type == nil then
-    if config.cmake_soft_link_compile_commands then
+  if const.lsp_type == nil then
+    if const.cmake_soft_link_compile_commands then
       cmake.compile_commands_from_soft_link()
     end
   else
@@ -649,7 +649,7 @@ function cmake.configure_compile_commands()
 end
 
 function cmake.compile_commands_from_soft_link()
-  if config.build_directory == nil or config.lsp_type ~= nil then return end
+  if config.build_directory == nil or const.lsp_type ~= nil then return end
 
   local source = config.build_directory.filename .. "/compile_commands.json"
   local destination = vim.loop.cwd() .. "/compile_commands.json"
@@ -659,10 +659,10 @@ function cmake.compile_commands_from_soft_link()
 end
 
 function cmake.compile_commands_from_preset()
-  if config.build_directory == nil then return end
+  if config.build_directory == nil or const.lsp_type == nil then return end
 
   local buf = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_active_clients({ name = config.lsp_type })
+  local clients = vim.lsp.get_active_clients({ name = const.lsp_type })
   for _, client in ipairs(clients) do
     local lspbufs = vim.lsp.get_buffers_by_client_id(client.id)
     for _, bufid in ipairs(lspbufs) do
@@ -674,7 +674,7 @@ function cmake.compile_commands_from_preset()
 end
 
 function cmake.clangd_on_new_config(new_config)
-  config.lsp_type = "clangd"
+  const.lsp_type = "clangd"
 
   local found = false
   local arg = "--compile-commands-dir=" .. config.build_directory.filename
@@ -688,11 +688,10 @@ function cmake.clangd_on_new_config(new_config)
   if found ~= true then
     table.insert(new_config.cmd, arg)
   end
-  vim.notify("DEBUG: " .. arg)
 end
 
 function cmake.ccls_on_new_config(new_config)
-  config.lsp_type = "ccls"
+  const.lsp_type = "ccls"
 
   new_config.init_options.compilationDatabaseDirectory = config.build_directory.filename
 end

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -640,7 +640,7 @@ end
 
 function cmake.configure_compile_commands()
   if config.lsp_type == nil then
-    if config.soft_link_compile_commands then
+    if config.cmake_soft_link_compile_commands then
       cmake.compile_commands_from_soft_link()
     end
   else

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -58,6 +58,7 @@ function cmake.generate(opt, callback)
     )
     if build_directory ~= "" then
       config:update_build_dir(build_directory)
+      cmake.compile_commands_from_preset()
     end
     config:generate_build_directory()
 
@@ -74,12 +75,7 @@ function cmake.generate(opt, callback)
         if type(callback) == "function" then
           callback()
         end
-        if const.cmake_soft_link_compile_commands then
-          utils.softlink(
-            config.build_directory.filename .. "/compile_commands.json",
-            vim.loop.cwd() .. "/compile_commands.json"
-          )
-        end
+        cmake.configure_compile_commands()
       end,
       cmake_console_position = const.cmake_console_position,
       cmake_show_console = const.cmake_show_console,
@@ -114,6 +110,7 @@ function cmake.generate(opt, callback)
   else
     config:update_build_dir(const.cmake_build_directory_prefix .. config.build_type)
   end
+  cmake.compile_commands_from_preset()
 
   config:generate_build_directory()
 
@@ -133,13 +130,7 @@ function cmake.generate(opt, callback)
       if type(callback) == "function" then
         callback()
       end
-
-      if const.cmake_soft_link_compile_commands then
-        utils.softlink(
-          config.build_directory.filename .. "/compile_commands.json",
-          vim.loop.cwd() .. "/compile_commands.json"
-        )
-      end
+      cmake.configure_compile_commands()
     end,
     cmake_console_position = const.cmake_console_position,
     cmake_show_console = const.cmake_show_console,
@@ -648,6 +639,50 @@ end
 function cmake.has_cmake_preset()
   local presets_file = presets.check()
   return presets_file ~= nil
+end
+
+function cmake.configure_compile_commands()
+  if const.cmake_soft_link_compile_commands then
+    utils.softlink(
+      config.build_directory.filename .. "/compile_commands.json",
+      vim.loop.cwd() .. "/compile_commands.json"
+    )
+  end
+  cmake.compile_commands_from_preset()
+end
+
+function cmake.compile_commands_from_preset()
+  if const.cmake_compile_commands_from_preset then
+    local lspconfig = require "lspconfig"
+    for _, client in ipairs(vim.lsp.get_active_clients()) do
+      vim.notify("Checking lsp " .. client.name)
+      if client.name == "ccls" then
+        lspconfig.ccls.setup {
+          init_options = {
+            compilationDatabaseDirectory = config.build_directory.filename,
+          },
+        }
+      elseif client.name == "clangd" then
+        lspconfig.clangd.setup {
+          on_new_config = function(new_config)
+            local found = false
+            local arg = "--compile-commands-dir=" .. config.build_directory.filename
+            for _, v in ipairs(new_config.cmd) do
+              if string.find(v, "--compile-commands-dir=") ~= nil then
+                v = arg
+                found = true
+                break
+              end
+            end
+            if not found then
+              table.insert(new_config.cmd, arg)
+            end
+          end
+        }
+        vim.notify("clangd: compile-commands-dir set to " .. config.build_directory.filename)
+      end
+    end
+  end
 end
 
 return cmake

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -128,6 +128,7 @@ function cmake.generate(opt, callback)
       if type(callback) == "function" then
         callback()
       end
+      cmake.configure_compile_commands()
     end,
     cmake_console_position = const.cmake_console_position,
     cmake_show_console = const.cmake_show_console,

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -47,7 +47,7 @@ end
 
 function utils.show_cmake_console(cmake_console_position, cmake_console_size)
   vim.api.nvim_command(cmake_console_position .. " copen " .. cmake_console_size)
-  vim.api.nvim_command("wincmd j")
+  vim.api.nvim_command("wincmd p")
 end
 
 function utils.close_cmake_console()

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -163,4 +163,13 @@ function utils.rmdir(dir)
   end
 end
 
+function utils.file_exists(path)
+  local file = io.open(path, "r")
+  if file then
+    file:close()
+    return true
+  end
+  return false
+end
+
 return utils


### PR DESCRIPTION
This adds an alternative to soft-linking compile_comands.json by adding functions that users can call in the on_new_config callback for clangd or ccls when using lspconfig.
It sets the compilation database directory to their current preset build directory and updates this path on regen.

The only existing behavior that had to be modified is in utils.show_cmake_console() where it now returns focus to the previous window on open. This is done because when restarting the language server it incorrectly uses the current buffer as the attach target instead of the previously attached buffer.