### PR TITLE
Launch from build directory fix, and can scroll output

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ require("cmake-tools").setup {
   cmake_build_directory_prefix = "cmake_build_", -- when cmake_build_directory is "", this option will be activated
   cmake_generate_options = { "-D", "CMAKE_EXPORT_COMPILE_COMMANDS=1" },
   cmake_regenerate_on_save = true, -- Saves CMakeLists.txt file only if mofified.
-  cmake_launch_from_built_binary_directory = true, -- WIP: see #47 and #34
   cmake_soft_link_compile_commands = true, -- if softlink compile commands json file
   cmake_build_options = {},
   cmake_console_size = 10, -- cmake output window height

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -4,7 +4,6 @@ local const = {
   cmake_command = "cmake",                                          -- cmake command path
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- it will be activated when invoke `cmake.generate`
   cmake_regenerate_on_save = true,
-  cmake_launch_from_built_binary_directory = true,
   cmake_soft_link_compile_commands = true,
   cmake_compile_commands_from_preset = false,
   cmake_build_options = {},              -- it will be activated when invoke `cmake.build`

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -68,41 +68,27 @@ function utils.execute(executable, opts)
   -- save all
   vim.cmd("wall")
   -- print("EXECUTABLE", executable)
-  if const.cmake_launch_from_built_binary_directory then
-    utils.job = Job:new({
-      command = executable,
-      args = {},
-      cwd = opts.cmake_launch_path,
-      on_stdout = vim.schedule_wrap(append_to_cmake_console),
-      on_stderr = vim.schedule_wrap(append_to_cmake_console),
-      on_exit = vim.schedule_wrap(function(_, code, signal)
-        append_to_cmake_console("Exited with code " .. (signal == 0 and code or 128 + signal))
-        if code == 0 and signal == 0 then
-          if opts.on_success then
-            opts.on_success()
-          end
-        elseif opts.cmake_show_console == "only_on_error" then
-          utils.show_cmake_console(opts.cmake_console_position, opts.cmake_console_size)
-          vim.api.nvim_command("cbottom")
+  utils.job = Job:new({
+    command = executable,
+    args = {},
+    cwd = opts.cmake_launch_path,
+    on_stdout = vim.schedule_wrap(append_to_cmake_console),
+    on_stderr = vim.schedule_wrap(append_to_cmake_console),
+    on_exit = vim.schedule_wrap(function(_, code, signal)
+      append_to_cmake_console("Exited with code " .. (signal == 0 and code or 128 + signal))
+      if code == 0 and signal == 0 then
+        if opts.on_success then
+          opts.on_success()
         end
-      end),
-    })
+      elseif opts.cmake_show_console == "only_on_error" then
+        utils.show_cmake_console(opts.cmake_console_position, opts.cmake_console_size)
+        vim.api.nvim_command("cbottom")
+      end
+    end),
+  })
 
-    utils.job:start()
-    return utils.job
-  else
-    local set_bufname = "file " .. opts.bufname
-    local prefix = string.format("%s %d new", opts.cmake_console_position, opts.cmake_console_size)
-    utils.close_cmake_console();
-    vim.cmd(prefix .. " | term " .. executable)
-    vim.opt_local.relativenumber = false
-    vim.opt_local.number = false
-    vim.cmd(set_bufname)
-    vim.bo.buflisted = false
-    vim.cmd("startinsert")
-  end
-
-
+  utils.job:start()
+  return utils.job
 end
 
 function utils.softlink(src, target)


### PR DESCRIPTION
Solves https://github.com/Civitasv/cmake-tools.nvim/pull/47#issuecomment-1545068911

The intended behaviour for #34(on by default), but also keeps the old behaviour :D