### PR TITLE
Fix buffer handling in windows 10, and added Autocmd 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.luarc.json

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -761,4 +761,17 @@ if const.cmake_regenerate_on_save == true then
   })
 end
 
+-- For win32, we have a command to escape insert mode after proccess extis
+-- because, we want to scroll the buffer output after completion of execution
+local is_win32 = vim.fn.has("win32")
+if (is_win32 == 1) then
+  vim.api.nvim_create_autocmd("TermClose", {
+    group    = "cmaketools",
+    callback =  function()
+      vim.cmd.stopinsert()
+      vim.api.nvim_feedkeys('<C-\\><C-n><CR>', 'n', false)
+    end
+  })
+end
+
 return cmake

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -71,6 +71,8 @@ function utils.execute(executable, opts)
   local set_bufname = "file " .. opts.bufname
   local prefix = string.format("%s %d new", opts.cmake_console_position, opts.cmake_console_size)
 
+  utils.close_cmake_console();
+
   -- TODO: Create a common output stream for all cmake related tasks and split running cmake tasks into terminals
     -- This requires support form either 'pleanary.nvim-plenary-job', or 'jobstart()' api
 
@@ -79,23 +81,22 @@ function utils.execute(executable, opts)
   -- local temp = " " -- This is only for testing
   for _, buf_nr in ipairs(all_buffs) do
     local name = vim.api.nvim_buf_get_name(buf_nr)
-    local test = string.match(name, opts.cmake_launch_path) == opts.cmake_launch_path
+    local test = string.match(name, set_bufname) == set_bufname
     -- print(test)
     -- temp = temp .. name ..": " .. tostring(test) .. ", "
     if test then
       -- the buffer is already avaliable
       vim.api.nvim_buf_delete(buf_nr,{force=true})
+      vim.cmd(set_bufname)
       break
     end
   end
   -- print(temp)
 
-  utils.close_cmake_console();
   vim.cmd(prefix .. " | term " .. "cd " .. opts.cmake_launch_path .. " && " .. executable)
-  vim.cmd(set_bufname)
   vim.opt_local.relativenumber = false
   vim.opt_local.number = false
-  vim.bo.buflisted = true -- We set this to true, so that we can detect in in vim.api.nvim_list_bufs(), a few lines above.
+  vim.bo.buflisted = false -- We set this to true, so that we can detect in in vim.api.nvim_list_bufs(), a few lines above.
   vim.cmd("startinsert")
 end
 

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -67,16 +67,35 @@ end
 function utils.execute(executable, opts)
   -- save all
   vim.cmd("wall")
-  print("EXECUTABLE", executable)
+  -- print("EXECUTABLE", executable)
   local set_bufname = "file " .. opts.bufname
   local prefix = string.format("%s %d new", opts.cmake_console_position, opts.cmake_console_size)
 
+  -- TODO: Create a common output stream for all cmake related tasks and split running cmake tasks into terminals
+    -- This requires support form either 'pleanary.nvim-plenary-job', or 'jobstart()' api
+
+  -- check if buufer exists. If it exists, delete it!
+  local all_buffs = vim.api.nvim_list_bufs()
+  -- local temp = " " -- This is only for testing
+  for _, buf_nr in ipairs(all_buffs) do
+    local name = vim.api.nvim_buf_get_name(buf_nr)
+    local test = string.match(name, opts.cmake_launch_path) == opts.cmake_launch_path
+    -- print(test)
+    -- temp = temp .. name ..": " .. tostring(test) .. ", "
+    if test then
+      -- the buffer is already avaliable
+      vim.api.nvim_buf_delete(buf_nr,{force=true})
+      break
+    end
+  end
+  -- print(temp)
+
   utils.close_cmake_console();
   vim.cmd(prefix .. " | term " .. "cd " .. opts.cmake_launch_path .. " && " .. executable)
+  vim.cmd(set_bufname)
   vim.opt_local.relativenumber = false
   vim.opt_local.number = false
-  vim.cmd(set_bufname)
-  vim.bo.buflisted = false
+  vim.bo.buflisted = true -- We set this to true, so that we can detect in in vim.api.nvim_list_bufs(), a few lines above.
   vim.cmd("startinsert")
 end
 


### PR DESCRIPTION
Fix buffer handling in windows 10, and added Autocmd for scrolling buffer output after process completion.

- [x] Tested on Windows 10
- [x] Tested on Linux
- [ ] Tested on MacOS