### PR TITLE
build_directory ignored when debugging

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -421,7 +421,7 @@ if has_nvim_dap then
           local dap_config = {
             name = config.launch_target,
             program = target_path,
-            cwd = cwd = getPath(result.data, "/"),
+            cwd = getPath(result.data, "/"),
             args = cmake:get_launch_args(),
           }
           -- close cmake console

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -421,7 +421,7 @@ if has_nvim_dap then
           local dap_config = {
             name = config.launch_target,
             program = target_path,
-            cwd = vim.loop.cwd(),
+            cwd = cwd = getPath(result.data, "/"),
             args = cmake:get_launch_args(),
           }
           -- close cmake console


### PR DESCRIPTION
When debugging the current working directory is set, whereas when running normally the build directory is used  