### PR TITLE
Working with terminals

### DIFF
--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -18,6 +18,7 @@ local Config = {
   kit = nil,
   configure_preset = nil,
   build_preset = nil,
+  cmake_startup = nil,
   main_terminal = nil,
   run_executable_terminals = {},
   debug_executable_terminals = {}

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -18,6 +18,9 @@ local Config = {
   kit = nil,
   configure_preset = nil,
   build_preset = nil,
+  main_terminal = nil,
+  run_executable_terminals = {},
+  debug_executable_terminals = {}
 }
 
 function Config:new(const)

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -27,6 +27,8 @@ local const = {
     keep_single_terminal_static = true,
     only_1_terminal_per_tab = true,
     single_terminal_window_per_tab = true,
+    terminal_split_direction = 'below',
+    terminal_split_size = 15,
   }
 }
 

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -22,6 +22,12 @@ local const = {
     runInTerminal = true,
     console = "integratedTerminal",
   },
+  cmake_use_terminals = true,
+  cmake_terminal_opts = {
+    keep_single_terminal_static = true,
+    only_1_terminal_per_tab = true,
+    single_terminal_window_per_tab = true,
+  }
 }
 
 return const

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -22,7 +22,7 @@ local const = {
     runInTerminal = true,
     console = "integratedTerminal",
   },
-  cmake_use_terminals = true,
+  cmake_use_terminals = true, -- Main option to enable to disable using terminals
   cmake_terminal_opts = {
     keep_single_terminal_static = true,
     only_1_terminal_per_tab = true,

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -27,8 +27,11 @@ local const = {
     keep_single_terminal_static = true,
     only_1_terminal_per_tab = true,
     single_terminal_window_per_tab = true,
+    show_terminal = true,
+    focus_on_terminal = true,
     terminal_split_direction = 'below',
     terminal_split_size = 15,
+    main_terminal_name = "CMake Main Terminal",
   }
 }
 

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -29,7 +29,7 @@ local const = {
     single_terminal_window_per_tab = true,
     show_terminal = true,
     focus_on_terminal = true,
-    terminal_split_direction = 'below',
+    terminal_split_direction = "horizontal", -- "horizontal" "vertical"
     terminal_split_size = 15,
     main_terminal_name = "CMake Main Terminal",
   }

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -70,18 +70,36 @@ function cmake.generate(opt, callback)
     vim.list_extend(args, fargs)
 
     --[[ print(unpack(args)) ]]
-    return utils.run(const.cmake_command, {}, args, {
-      on_success = function()
-        if type(callback) == "function" then
-          callback()
-        end
-        cmake.configure_compile_commands()
-      end,
-      terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
-      cmake_console_position = const.cmake_console_position,
-      cmake_show_console = const.cmake_show_console,
-      cmake_console_size = const.cmake_console_size
-    })
+    if const.cmake_use_terminals == true then
+      return
+      -- vim.schedule(function()
+          utils.run(const.cmake_command, {}, args, {
+            on_success = function()
+              if type(callback) == "function" then
+                callback()
+              end
+              cmake.configure_compile_commands()
+            end,
+            terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
+            cmake_console_position = const.cmake_console_position,
+            cmake_show_console = const.cmake_show_console,
+            cmake_console_size = const.cmake_console_size
+          })
+      -- end)
+    else
+      return utils.run(const.cmake_command, {}, args, {
+        on_success = function()
+          if type(callback) == "function" then
+            callback()
+          end
+          cmake.configure_compile_commands()
+        end,
+        terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
+        cmake_console_position = const.cmake_console_position,
+        cmake_show_console = const.cmake_show_console,
+        cmake_console_size = const.cmake_console_size
+      })
+    end
   end
 
   -- if exists cmake-kits.json, kit is used to set
@@ -125,18 +143,36 @@ function cmake.generate(opt, callback)
   vim.list_extend(args, config.generate_options)
   vim.list_extend(args, fargs)
 
-  return utils.run(const.cmake_command, kit_option.env, args, {
-    on_success = function()
-      if type(callback) == "function" then
-        callback()
-      end
-      cmake.configure_compile_commands()
-    end,
-    terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
-    cmake_console_position = const.cmake_console_position,
-    cmake_show_console = const.cmake_show_console,
-    cmake_console_size = const.cmake_console_size
-  })
+  if const.cmake_use_terminals == true then
+    return
+    -- vim.schedule(function()
+        utils.run(const.cmake_command, kit_option.env, args, {
+          on_success = function()
+            if type(callback) == "function" then
+              callback()
+            end
+            cmake.configure_compile_commands()
+          end,
+          terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
+          cmake_console_position = const.cmake_console_position,
+          cmake_show_console = const.cmake_show_console,
+          cmake_console_size = const.cmake_console_size
+        })
+    -- end)
+  else
+    return utils.run(const.cmake_command, kit_option.env, args, {
+      on_success = function()
+        if type(callback) == "function" then
+          callback()
+        end
+        cmake.configure_compile_commands()
+      end,
+      terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
+      cmake_console_position = const.cmake_console_position,
+      cmake_show_console = const.cmake_show_console,
+      cmake_console_size = const.cmake_console_size
+    })
+  end
 end
 
 --- Clean targets
@@ -152,17 +188,34 @@ function cmake.clean(callback)
 
   local args = { "--build", config.build_directory.filename, "--target", "clean" }
 
-  return utils.run(const.cmake_command, {}, args, {
-    on_success = function()
-      if type(callback) == "function" then
-        callback()
-      end
-    end,
-    terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
-    cmake_console_position = const.cmake_console_position,
-    cmake_show_console = const.cmake_show_console,
-    cmake_console_size = const.cmake_console_size
-  })
+  if const.cmake_use_terminals == true then
+    return
+    -- vim.schedule(function()
+        utils.run(const.cmake_command, {}, args, {
+          on_success = function()
+            if type(callback) == "function" then
+              callback()
+            end
+          end,
+          terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
+          cmake_console_position = const.cmake_console_position,
+          cmake_show_console = const.cmake_show_console,
+          cmake_console_size = const.cmake_console_size
+        })
+    -- end)
+  else
+    return utils.run(const.cmake_command, {}, args, {
+      on_success = function()
+        if type(callback) == "function" then
+          callback()
+        end
+      end,
+      terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
+      cmake_console_position = const.cmake_console_position,
+      cmake_show_console = const.cmake_show_console,
+      cmake_console_size = const.cmake_console_size
+    })
+  end
 end
 
 --- Build this project using the make toolchain of target platform
@@ -208,17 +261,34 @@ function cmake.build(opt, callback)
     vim.list_extend(args, fargs)
   end
 
-  return utils.run(const.cmake_command, {}, args, {
-    on_success = function()
-      if type(callback) == "function" then
-        callback()
-      end
-    end,
-    terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
-    cmake_console_position = const.cmake_console_position,
-    cmake_show_console = const.cmake_show_console,
-    cmake_console_size = const.cmake_console_size
-  })
+  if const.cmake_use_terminals == true then
+    return
+        -- vim.schedule(function()
+            utils.run(const.cmake_command, {}, args, {
+              on_success = function()
+                if type(callback) == "function" then
+                  callback()
+                end
+              end,
+              terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
+              cmake_console_position = const.cmake_console_position,
+              cmake_show_console = const.cmake_show_console,
+              cmake_console_size = const.cmake_console_size
+            })
+          -- end)
+  else
+    return utils.run(const.cmake_command, {}, args, {
+      on_success = function()
+        if type(callback) == "function" then
+          callback()
+        end
+      end,
+      terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
+      cmake_console_position = const.cmake_console_position,
+      cmake_show_console = const.cmake_show_console,
+      cmake_console_size = const.cmake_console_size
+    })
+  end
 end
 
 --- Clean Rebuild: Clean the project and then Rebuild the target
@@ -345,38 +415,53 @@ function cmake.run(opt, callback)
   else -- if result_code == Types.SELECTED_LAUNCH_TARGET_NOT_BUILT
     -- Build select launch target every time
     config.build_target = config.launch_target
-    return cmake.build({ fargs = utils.deepcopy(opt.fargs) }, function()
-      vim.schedule(function()
-        result = config:get_launch_target()
-        -- print(utils.dump(result))
-        -- print("TARGET", target_path)
-        local target_path = result.data
-        local is_win32 = vim.fn.has("win32")
-        if (is_win32 == 1) then
-          -- Prints the output in the same cmake window as in wsl/linux
-          local new_s = getPath(target_path, "/")
-          -- print(getPath(target_path,sep))
-          return utils.execute(target_path, {
-            bufname = vim.fn.expand("%:p"),
-            cmake_launch_path = new_s,
-            cmake_console_position = const.cmake_console_position,
-            cmake_console_size = const.cmake_console_size,
-            cmake_launch_args = cmake:get_launch_args()
-          })
-        else
-          -- print("target_path: " .. target_path)
-          local new_s = getPath(target_path, "/")
-          if const.cmake_use_terminals == true then
-            local exec_name = {'"' .. target_path .. '"',}
-            utils.run(const.cmake_command, {}, exec_name, {
+    -- print("Result target is :" .. config.build_target)
+    if const.cmake_use_terminals == true then
+      print("TARGET")
+      return
+      -- vim.schedule(function()
+      -- cmake.build({ fargs = utils.deepcopy(opt.fargs) }, function()
+          cmake.build({}, function()
+            result = config:get_launch_target()
+            -- print(utils.dump(result))
+            local target_path = result.data
+            print("TARGET", target_path)
+            local new_s = getPath(target_path, "/")
+            local executable = '"' .. target_path .. '"'
+            local args = {} -- TODO: implement args
+            return utils.run(executable, {}, args, {
               terminal_buffer_name = const.cmake_terminal_opts.main_terminal_name,
+              run_task = true,
               cmake_launch_path = new_s,
               cmake_console_position = const.cmake_console_position,
               cmake_show_console = const.cmake_show_console,
               cmake_console_size = const.cmake_console_size,
               cmake_launch_args = cmake:get_launch_args()
             })
-          else -- Old QuickFix Lists
+            -- end)
+          end)
+    else
+      return cmake.build({ fargs = utils.deepcopy(opt.fargs) }, function()
+        -- vim.schedule(function()
+          result = config:get_launch_target()
+          -- print(utils.dump(result))
+          -- print("TARGET", target_path)
+          local target_path = result.data
+          local is_win32 = vim.fn.has("win32")
+          if (is_win32 == 1) then
+            -- Prints the output in the same cmake window as in wsl/linux
+            local new_s = getPath(target_path, "/")
+            -- print(getPath(target_path,sep))
+            return utils.execute(target_path, {
+              bufname = vim.fn.expand("%:p"),
+              cmake_launch_path = new_s,
+              cmake_console_position = const.cmake_console_position,
+              cmake_console_size = const.cmake_console_size,
+              cmake_launch_args = cmake:get_launch_args()
+            })
+          else
+            -- print("target_path: " .. target_path)
+            local new_s = getPath(target_path, "/")
             return utils.execute('"' .. target_path .. '"', {
               bufname = vim.fn.expand("%:t:r"),
               cmake_launch_path = new_s,
@@ -384,10 +469,10 @@ function cmake.run(opt, callback)
               cmake_console_size = const.cmake_console_size,
               cmake_launch_args = cmake:get_launch_args()
             })
-            end
-        end
+          end
+        -- end)
       end)
-    end)
+    end
   end
 end
 

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -453,6 +453,10 @@ end
 -------------------------- CMake New Funcs ---------------------------
 ----------------------------------------------------------------------
 
+function cmake.sandbox(opt, callback)
+  print('Sandbox Command')
+end
+
 function cmake.generate_new(opt, callback)
 
   -- If term did not already exist, create it.

--- a/lua/cmake-tools/kits.lua
+++ b/lua/cmake-tools/kits.lua
@@ -84,7 +84,7 @@ function kits.build_env_and_args(kit_name)
   -- if exists `compilers` option, then set variable for cmake
   if kit.compilers then
     for lang, compiler in pairs(kit.compilers) do
-      add_args({ "-DCMAKE_" .. lang .. "_COMPILER:FILEPATH=" .. compiler })
+      add_args({ "-DCMAKE_" .. lang .. "_COMPILER:FILEPATH=" .. "'" .. compiler .. "'" })
     end
   end
   if kit.generator then

--- a/lua/cmake-tools/os_config.lua
+++ b/lua/cmake-tools/os_config.lua
@@ -1,0 +1,87 @@
+local os_config = {}
+
+local function enum(tbl)
+  local length = #tbl
+  for i = 1, length do
+    local v = tbl[i]
+    tbl[v] = i
+  end
+  return tbl
+end
+
+local Os_List = enum({
+  "Win32",
+  "Unix",
+  "MacOS"
+})
+
+-- Detect os on startup
+local is_macunix = vim.fn.has("macunix")
+local is_win32 = vim.fn.has("win32")
+local is_wsl = vim.fn.has("wsl")
+
+function os_config.get_os()
+  if is_win32 == 1 then
+    os_config.my_os = Os_List.Win32
+    -- print('Win32')
+  elseif is_wsl == 1 then
+    os_config.my_os = Os_List.Unix
+    -- print('Unix')
+  elseif is_macunix == 1 then
+    os_config.my_os = Os_List.MacOS
+    -- print('MacOS')
+  else
+    vim.notify("CMake Tools: OS is Not detected!", vim.log.levels.ERROR, {title = "CMake"})
+  end
+  return os_config.my_os
+end
+
+--- TODO: All this is intended to do is to prevent the user from spamming multiple CMake <Taks> Commands, all at once.
+function os_config.get_process_wrapper_for(cmd)
+  local my_os = os_config.get_os()
+
+  if my_os == Os_List.Win32 then
+    local wrapped_cmd = "Start-Process -FilePath pwsh.exe -ArgumentList \"-noprofile\", \"-Command\"," .. cmd .. " -NoNewWindow "
+    -- local wrapped_cmd =  "Start-Process -FilePath pwsh  \"-Command " .. cmd .." && echo 'done!' \" -NoNewWindow -ArgumentList '-noprofile -command \"Start-Process cmd.exe -Verb RunAs -args /k\"'"
+    -- wrapped_cmd = wrapped_cmd .. string.char(13)
+    -- print('wrapped_cmd: ' .. wrapped_cmd)
+    return wrapped_cmd
+  elseif my_os == Os_List.Unix then
+    -- TODO: Wrapped command here
+  elseif my_os == Os_List.MacOS then
+    -- TODO: Wrapped command here
+  end
+end
+
+function os_config.start_local_shell(split_direction)
+  if os_config.get_os() == Os_List.Win32 then
+    -- vim.cmd(':setlocal shell=pwsh\\ -noprofile')
+    -- os_config.set_local_opts()
+    vim.cmd(':' .. split_direction .. ' :sp | :term') -- Creater terminal in a split
+  elseif os_config.get_os()  == Os_List.Unix then
+    -- TODO: Wrapped command here
+  elseif os_config.get_os() == Os_List.MacOS then
+    -- TODO: Wrapped command here
+  end
+end
+
+function os_config.set_local_opts()
+  if os_config.get_os() == Os_List.Win32 then
+    vim.cmd(':setlocal shell=pwsh')
+    local powershell_options = {
+      shell = vim.fn.executable "pwsh" == 1 and "pwsh" or "powershell",
+      shellcmdflag = "-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;",
+      shellredir = "-RedirectStandardOutput %s -NoNewWindow -Wait",
+      shellpipe = "2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode",
+      shellquote = "",
+      shellxquote = "",
+    }
+
+    for option, value in pairs(powershell_options) do
+      vim.opt[option] = value
+      -- vim.cmd(':setlocal ' .. option .. "=" ..value)
+    end
+  end
+end
+
+return os_config

--- a/lua/cmake-tools/os_config.lua
+++ b/lua/cmake-tools/os_config.lua
@@ -31,7 +31,7 @@ function os_config.get_os()
     os_config.my_os = Os_List.MacOS
     -- print('MacOS')
   else
-    vim.notify("CMake Tools: OS is Not detected!", vim.log.levels.ERROR, {title = "CMake"})
+    vim.notify("CMake Tools: OS is Not detected!", vim.log.levels.ERROR, { title = "CMake" })
   end
   return os_config.my_os
 end
@@ -41,7 +41,8 @@ function os_config.get_process_wrapper_for(cmd)
   local my_os = os_config.get_os()
 
   if my_os == Os_List.Win32 then
-    local wrapped_cmd = "Start-Process -FilePath pwsh.exe -ArgumentList \"-noprofile\", \"-Command\"," .. cmd .. " -NoNewWindow "
+    local wrapped_cmd = "Start-Process -FilePath pwsh.exe -ArgumentList \"-noprofile\", \"-Command\"," ..
+        cmd .. " -PassThru -NoNewWindow | Wait-Process"
     -- local wrapped_cmd =  "Start-Process -FilePath pwsh  \"-Command " .. cmd .." && echo 'done!' \" -NoNewWindow -ArgumentList '-noprofile -command \"Start-Process cmd.exe -Verb RunAs -args /k\"'"
     -- wrapped_cmd = wrapped_cmd .. string.char(13)
     -- print('wrapped_cmd: ' .. wrapped_cmd)
@@ -55,10 +56,11 @@ end
 
 function os_config.start_local_shell(split_direction)
   if os_config.get_os() == Os_List.Win32 then
-    -- vim.cmd(':setlocal shell=pwsh\\ -noprofile')
-    -- os_config.set_local_opts()
-    vim.cmd(':' .. split_direction .. ' :sp | :term') -- Creater terminal in a split
-  elseif os_config.get_os()  == Os_List.Unix then
+    vim.cmd(':' .. split_direction .. ' sp | :term')           -- Creater terminal in a split
+    local terminal_buffer_idx = vim.api.nvim_get_current_buf() -- Get the buffer idx
+    vim.api.nvim_buf_set_option(terminal_buffer_idx, 'bufhidden', 'hide')
+    return terminal_buffer_idx
+  elseif os_config.get_os() == Os_List.Unix then
     -- TODO: Wrapped command here
   elseif os_config.get_os() == Os_List.MacOS then
     -- TODO: Wrapped command here
@@ -70,7 +72,8 @@ function os_config.set_local_opts()
     vim.cmd(':setlocal shell=pwsh')
     local powershell_options = {
       shell = vim.fn.executable "pwsh" == 1 and "pwsh" or "powershell",
-      shellcmdflag = "-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;",
+      shellcmdflag =
+      "-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;",
       shellredir = "-RedirectStandardOutput %s -NoNewWindow -Wait",
       shellpipe = "2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode",
       shellquote = "",

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -190,7 +190,6 @@ end
 -- Error Checking in CMake Task: https://stackoverflow.com/questions/7402587/run-command2-only-if-command1-succeeded-in-cmd-windows-shell
 ---Check if main terminal has active job
 function utils.main_term_has_active_job(terminal_buffer_name)
-
   -- Lookup the terminal buffer idx from it's name
   local terminal_buffer_idx = nil
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
@@ -203,22 +202,43 @@ function utils.main_term_has_active_job(terminal_buffer_name)
 
   -- If terminal is found, then get the last line in the buffer, and check for substring: 'CMake Task Finished'
   if terminal_buffer_idx then
-
     -- Get lines, and check for substring
     local term_proc = vim.fn.jobpid(vim.api.nvim_buf_get_var(terminal_buffer_idx, 'terminal_job_id'))
     local term_child_procs = vim.api.nvim_get_proc_children(term_proc)
     if next(term_child_procs) == nil then
       return false -- Term has no child process. New process can be spwanned
     end
-      utils.error(
-        "A CMake task is already running: "
-        .. utils.main_term_job
-        .. " Stop it before trying to run a new CMake Build/Generate/Clean/CleanRebuild/Install."
-      )
-      return true -- Child processes exist. Cannot launch new task
+    utils.error(
+      "A CMake task is already running: "
+      .. utils.main_term_job
+      .. " Stop it before trying to run a new CMake Build/Generate/Clean/CleanRebuild/Install."
+    )
+    return true -- Child processes exist. Cannot launch new task
   else
     utils.error("Main CMake Console does not exist! : CMAKE ERROR!")
     return true
+  end
+end
+
+function utils.create_if_term_does_not_exist(terminal_buffer_name)
+  -- Lookup the terminal buffer idx from it's name
+  local terminal_buffer_idx = nil
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    local name = vim.api.nvim_buf_get_name(bufnr)
+    if name == terminal_buffer_name then
+      terminal_buffer_idx = bufnr
+      break
+    end
+  end
+
+  if terminal_buffer_idx ~= nil then
+    return true, terminal_buffer_idx
+  else
+    -- TODO: replace 'below' with const.position
+    vim.cmd(':' .. 'below' .. 'sp | :term')                              -- Creater terminal in a split
+    terminal_buffer_idx = vim.api.nvim_get_current_buf()                 -- Get the buffer idx
+    vim.api.nvim_buf_set_name(terminal_buffer_idx, terminal_buffer_name) -- Set the buffer name
+    return false, terminal_buffer_idx
   end
 end
 

--- a/plugin/cmake-tools.lua
+++ b/plugin/cmake-tools.lua
@@ -6,6 +6,17 @@ local has_nvim_dap, _ = pcall(require, "dap")
 
 ---------------- Commands ------------------
 
+--- CMake Test Command
+vim.api.nvim_create_user_command(
+  "CMakeSandbox", -- name
+  cmake_tools.sandbox, -- command
+  { -- opts
+    nargs = "*",
+    bang = true,
+    desc = "CMake Snadbox configure",
+  }
+)
+
 --- CMake
 vim.api.nvim_create_user_command(
   "CMakeGenerate", -- name

--- a/plugin/cmake-tools.lua
+++ b/plugin/cmake-tools.lua
@@ -6,28 +6,6 @@ local has_nvim_dap, _ = pcall(require, "dap")
 
 ---------------- Commands ------------------
 
---- CMake Test Command
-vim.api.nvim_create_user_command(
-  "CMakeASandbox", -- name
-  cmake_tools.sandbox, -- command
-  { -- opts
-    nargs = "*",
-    bang = true,
-    desc = "CMake Sandbox configure",
-  }
-)
-
---- CMake Test Command
-vim.api.nvim_create_user_command(
-  "CMakeASleep", -- name
-  cmake_tools.launch_test_command, -- command
-  { -- opts
-    nargs = "*",
-    bang = true,
-    desc = "CMake Terminal Sleep Command",
-  }
-)
-
 --- CMake
 vim.api.nvim_create_user_command(
   "CMakeGenerate", -- name

--- a/plugin/cmake-tools.lua
+++ b/plugin/cmake-tools.lua
@@ -8,12 +8,23 @@ local has_nvim_dap, _ = pcall(require, "dap")
 
 --- CMake Test Command
 vim.api.nvim_create_user_command(
-  "CMakeSandbox", -- name
+  "CMakeASandbox", -- name
   cmake_tools.sandbox, -- command
   { -- opts
     nargs = "*",
     bang = true,
-    desc = "CMake Snadbox configure",
+    desc = "CMake Sandbox configure",
+  }
+)
+
+--- CMake Test Command
+vim.api.nvim_create_user_command(
+  "CMakeASleep", -- name
+  cmake_tools.launch_test_command, -- command
+  { -- opts
+    nargs = "*",
+    bang = true,
+    desc = "CMake Terminal Sleep Command",
   }
 )
 


### PR DESCRIPTION
## This is a W.I.P.

I am opening this dirty draft PR, as a communication channel. Here is what I am currently doing:

1. The `on_success` callbacks are not implemented (require pipes?)
2. The `os_config.lua` file is only for dealing with child procs and their outputs. (If there is a suitable method where the output from the buffer does not get overwritten by the terminal emulator, this method would be ideal.

## TODO:

- [ ] vim.schedule/wrap the creation of terminals
- [ ] on_success callback command to the terminal (Either child procs or via pipes)
- [ ] Implement `cmake.stop()` for terminal
- [ ] Implement `cmake.install()` for terminal
- [ ] Add window handling back(which is the whole point of this PR)

Since my [inital test with window handling](https://github.com/Civitasv/cmake-tools.nvim/issues/55#issuecomment-1556581793), my local branch of cmake-tools was removed by [lazy](https://github.com/folke/lazy.nvim) 💀, since then I had to redo much of it, and so, currently there is no window handling.