### PR TITLE
Be able to configure custom path of kits, fix for #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,12 @@ require("cmake-tools").setup {
   cmake_generate_options = { "-D", "CMAKE_EXPORT_COMPILE_COMMANDS=1" },
   cmake_regenerate_on_save = true, -- Saves CMakeLists.txt file only if mofified.
   cmake_soft_link_compile_commands = true, -- if softlink compile commands json file
+  cmake_compile_commands_from_lsp = false, -- automatically set compile commands location using lsp
   cmake_build_options = {},
   cmake_console_size = 10, -- cmake output window height
   cmake_console_position = "belowright", -- "belowright", "aboveleft", ...
   cmake_show_console = "always", -- "always", "only_on_error"
+  cmake_kits_path = nil, -- global cmake kits path
   cmake_dap_configuration = { name = "cpp", type = "codelldb", request = "launch" }, -- dap configuration, optional
   cmake_variants_message = {
     short = { show = true },

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -4,12 +4,13 @@ local const = {
   cmake_command = "cmake", -- cmake command path
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- it will be activated when invoke `cmake.generate`
   cmake_regenerate_on_save = true,
-  cmake_soft_link_compile_commands = true,
-  cmake_compile_commands_from_preset = false,
+  cmake_soft_link_compile_commands = true, -- soft compile commands file to project root dir
+  cmake_compile_commands_from_lsp = false, -- automatically set compile commands location using lsp
   cmake_build_options = {}, -- it will be activated when invoke `cmake.build`
   cmake_console_position = "belowright", -- "bottom", "top"
   cmake_console_size = 10,
   cmake_show_console = "always", -- "always", "only_on_error"
+  cmake_kits_path = nil,
   cmake_variants_message = {
     short = { show = true },
     long = { show = true, max_length = 40 }

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -481,7 +481,7 @@ function cmake.select_kit(callback)
     return utils.error(result.message)
   end
 
-  local cmake_kits = kits.get()
+  local cmake_kits = kits.get(const.cmake_kits_path)
   if cmake_kits then
     -- Put selected kit first
     for idx, kit in ipairs(cmake_kits) do

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -84,7 +84,7 @@ function cmake.generate(opt, callback)
 
   -- if exists cmake-kits.json, kit is used to set
   -- environmental variables and args.
-  local kits_config = kits.parse()
+  local kits_config = kits.parse(const.cmake_kits_path)
   if kits_config and not config.kit then
     return cmake.select_kit(function()
       cmake.generate(opt, callback)
@@ -704,7 +704,7 @@ function cmake.configure_compile_commands()
     if const.cmake_soft_link_compile_commands then
       cmake.compile_commands_from_soft_link()
     end
-  else
+  elseif const.cmake_compile_commands_from_lsp then
     cmake.compile_commands_from_preset()
   end
 end

--- a/lua/cmake-tools/kits.lua
+++ b/lua/cmake-tools/kits.lua
@@ -5,21 +5,17 @@ function kits.parse(global_kits_path)
   -- helper function to find the config file
   -- returns file path if found, nil otherwise
   local function findcfg()
-    if global_kits_path ~= nil then
-      -- first, check if global cmake kits path is nil
-      return global_kits_path
-    else
-      -- then, check if local cmake kits file is exists
-      local files = vim.fn.readdir(".")
-      local file = nil
-      for _, f in ipairs(files) do -- iterate over files in current directory
-        if (f == "cmake-kits.json" or f == "CMakeKits.json") then -- if a kits config file is found
-          file = vim.fn.resolve("./" .. f)
-          break
-        end
+    local files = vim.fn.readdir(".")
+    -- it will use local kits path first,
+    -- otherwise, it will use global kits path
+    local file = global_kits_path
+    for _, f in ipairs(files) do -- iterate over files in current directory
+      if (f == "cmake-kits.json" or f == "CMakeKits.json") then -- if a kits config file is found
+        file = vim.fn.resolve("./" .. f)
+        break
       end
-      return file
     end
+    return file
   end
 
   -- start parsing

--- a/lua/cmake-tools/kits.lua
+++ b/lua/cmake-tools/kits.lua
@@ -36,9 +36,9 @@ function kits.parse(global_kits_path)
 end
 
 -- returns a list of descriptions of all kits
-function kits.get()
+function kits.get(global_kits_path)
   -- start parsing
-  local config = kits.parse()
+  local config = kits.parse(global_kits_path)
   local res = {}
   if config then -- if a config is found
     for _, item in ipairs(config) do

--- a/lua/cmake-tools/kits.lua
+++ b/lua/cmake-tools/kits.lua
@@ -1,24 +1,28 @@
 local kits = {}
 
 -- checks if there is a cmake-kits.json file and parses it to a Lua table
-function kits.parse()
+function kits.parse(global_kits_path)
   -- helper function to find the config file
   -- returns file path if found, nil otherwise
   local function findcfg()
-    local files = vim.fn.readdir(".")
-    local file = nil
-    for _, f in ipairs(files) do -- iterate over files in current directory
-      if (f == "cmake-kits.json" or f == "CMakeKits.json") then -- if a kits config file is found
-        file = vim.fn.resolve("./" .. f)
-        break
+    if global_kits_path ~= nil then
+      -- first, check if global cmake kits path is nil
+      return global_kits_path
+    else
+      -- then, check if local cmake kits file is exists
+      local files = vim.fn.readdir(".")
+      local file = nil
+      for _, f in ipairs(files) do -- iterate over files in current directory
+        if (f == "cmake-kits.json" or f == "CMakeKits.json") then -- if a kits config file is found
+          file = vim.fn.resolve("./" .. f)
+          break
+        end
       end
+      return file
     end
-
-    return file
   end
 
   -- start parsing
-
   local config = nil
 
   local file = findcfg() -- check for config file


### PR DESCRIPTION
This PR add an option for global kits path.

```lua
cmake_kits_path = nil,
```

If use specify `cmake_kits_path`, it will:

1. If there is no `CMakeKits.json` file at project root directory, it will use this global kits path.
2. Otherwise, it will use local cmake kits file.