### PR TITLE
Stop saving twice?

### DIFF
--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -62,9 +62,6 @@ end
 -- @param executable executable file
 -- @param opts execute options
 function utils.execute(executable, opts)
-  -- Please save all
-  vim.cmd("wall")
-
   -- First, if we use quickfix to generate, build, etc, we should close it
   if not opts.cmake_always_use_terminal then
     quickfix.close()


### PR DESCRIPTION
Do not save in execute, as we use terminals... if commands are chained, it just saves twice. The print message twice is ugly as we need to hit enter to escape the print message.