### PR TITLE
This is a fix for #60

### DIFF
--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -110,7 +110,6 @@ function Config:check_launch_target()
   end
 
   -- 2. not select launch target yet
-  -- print("SELECTED", self.launch_target)
   if not self.launch_target then
     return Result:new(Types.NOT_SELECT_LAUNCH_TARGET, nil, "You need to select launch target first")
   end
@@ -120,13 +119,11 @@ function Config:check_launch_target()
     return codemodel_targets
   end
   codemodel_targets = codemodel_targets.data
-  -- print("ALL TARGETS", utils.dump(codemodel_targets)) -- uncomment utils in preamble (import section) to enable this. disabling for Lua check in CI/CD pipleine
 
   for _, target in ipairs(codemodel_targets) do
     if self.launch_target == target["name"] then
       local target_info = self:get_code_model_target_info(target)
       local type = target_info["type"]:lower():gsub("_", " ")
-      -- print("TYPE", type)
       if type ~= "executable" then
         -- 3. selected target cannot execute
         return Result:new(Types.NOT_EXECUTABLE, nil, "You need to select a executable target")
@@ -151,7 +148,6 @@ function Config:get_launch_target()
   end
   local target_info = check_result.data
 
-  -- print(utils.dump(target_info))
   local target_path = target_info["artifacts"][1]["path"]
   target_path = Path:new(target_path)
   if not target_path:is_absolute() then
@@ -164,7 +160,7 @@ function Config:get_launch_target()
   if not target_path:is_file() then
     return Result:new(
       Types.SELECTED_LAUNCH_TARGET_NOT_BUILT,
-      nil,
+      target_path.filename,
       "Selected target is not built: " .. target_path.filename
     )
   end
@@ -181,7 +177,6 @@ function Config:check_build_target()
   end
 
   -- 2. not select build target yet
-  -- print("SELECTED", self.build_target)
   if not self.build_target then
     return Result:new(Types.NOT_SELECT_BUILD_TARGET, nil, "You need to select Build target first")
   end
@@ -191,13 +186,11 @@ function Config:check_build_target()
     return codemodel_targets
   end
   codemodel_targets = codemodel_targets.data
-  -- print("ALL TARGETS", utils.dump(codemodel_targets)) -- uncomment utils in preamble (import section) to enable this. disabling for Lua check in CI/CD pipleine
 
   for _, target in ipairs(codemodel_targets) do
     if self.build_target == target["name"] then
       local target_info = self:get_code_model_target_info(target)
       -- local type = target_info["type"]:lower():gsub("_", " ")
-      -- print("TYPE",type)
       return Result:new(Types.SUCCESS, target_info, "Success")
     end
   end
@@ -217,7 +210,6 @@ function Config:get_build_target()
     return check_result
   end
   local target_info = check_result.data
-  -- print(utils.dump(target_info))
   local target_path = target_info["artifacts"][1]["path"]
   target_path = Path:new(target_path)
   if not target_path:is_absolute() then
@@ -262,10 +254,8 @@ local function get_targets(config, opt)
 
   codemodel_targets = codemodel_targets.data
   for _, target in ipairs(codemodel_targets) do
-    -- print(dump(target))
     local target_info = config:get_code_model_target_info(target)
     local target_name = target_info["name"]
-    -- print(target_name)
     if target_name:find("_autogen") == nil then
       local type = target_info["type"]:lower():gsub("_", " ")
       local display_name = target_name .. " (" .. type .. ")"

--- a/lua/cmake-tools/quickfix.lua
+++ b/lua/cmake-tools/quickfix.lua
@@ -66,4 +66,12 @@ function quickfix.has_active_job()
   return true
 end
 
+function quickfix.stop()
+  quickfix.job:shutdown(1, 9)
+
+  for _, pid in ipairs(vim.api.nvim_get_proc_children(quickfix.job.pid)) do
+    vim.loop.kill(pid, 9)
+  end
+end
+
 return quickfix

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -3,7 +3,6 @@ local Result = require("cmake-tools.result")
 local Types = require("cmake-tools.types")
 local terminal = require("cmake-tools.terminal")
 local quickfix = require("cmake-tools.quickfix")
-local log = require("cmake-tools.log")
 
 -- local const = require("cmake-tools.const")
 
@@ -60,8 +59,9 @@ end
 
 --- Execute CMake launch target in terminal.
 -- @param executable executable file
+-- @param full_cmd full command line
 -- @param opts execute options
-function utils.execute(executable, opts)
+function utils.execute(executable, full_cmd, opts)
   -- Please save all
   vim.cmd("wall")
 
@@ -71,13 +71,13 @@ function utils.execute(executable, opts)
   end
 
   -- Then, execute it
-  terminal.execute(executable, opts)
+  terminal.execute(executable, full_cmd, opts)
 end
 
 function utils.softlink(src, target, opts)
   if opts.cmake_always_use_terminal and not utils.file_exists(target) then
     local cmd = "cmake -E create_symlink " .. src .. " " .. target
-    terminal.run(cmd, {}, {}, opts)
+    terminal.run(cmd, opts)
     return
   end
 
@@ -115,7 +115,7 @@ function utils.run(cmd, env, args, opts)
   vim.cmd("wall")
 
   if opts.cmake_always_use_terminal then
-    return terminal.run(cmd, env, args, opts)
+    return terminal.run(cmd, opts)
   else
     return quickfix.run(cmd, env, args, opts)
   end
@@ -125,7 +125,6 @@ end
 -- @return true if exists else false
 function utils.has_active_job(always_use_terminal)
   if always_use_terminal then
-    log.warn("This is an experimental feature! set \"cmake_always_use_terminal=false\" if this is causing trouble")
     return terminal.has_active_job()
   else
     return terminal.has_active_job() or quickfix.has_active_job()
@@ -145,6 +144,14 @@ function utils.file_exists(path)
     return false
   end
   return true
+end
+
+function utils.stop(opts)
+  if opts.cmake_always_use_terminal then
+    terminal.stop()
+  else
+    quickfix.stop()
+  end
 end
 
 return utils

--- a/lua/cmake-tools/variants.lua
+++ b/lua/cmake-tools/variants.lua
@@ -196,7 +196,6 @@ end
 
 -- given a variant, build an argument list for CMake
 function variants.build_arglist(variant)
-  --[[ print("VARIANT", utils.dump(variant)) ]]
   -- helper function to build a simple command line option that defines the CMAKE_BUILD_TYPE variable to `build_type`
   local function build_simple(build_type)
     return { "-D", "CMAKE_BUILD_TYPE:STRING=" .. build_type }


### PR DESCRIPTION
This is a fix for #60, instead using `on_success` function to chain commands, now I use `&&` to join multiple commands. For example, If uses invoke `CMakeRun`, and not yet `CMakeGenerate` and `CMakeBuild`, it will turn like `cmake -B out/Debug -S . -D CMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 && cmake --build out/Debug --target TEST && c
d /home/civitasv/Documents/workflow/test/cmake-test/out/Debug && ./TEST `.

It actually works really good. But it still have a little flaw: For the very first time, users must call `CMakeGenerate` once to generate build system. Then it will work just like quickfix version. I think it's totally acceptable.