### PR TITLE
Added new  terminal filetype for easier filtering of terminal buffers 

### DIFF
--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -42,6 +42,7 @@ local const = {
     start_insert_in_other_tasks = false, -- If you want to enter terminal with :startinsert upon launching all other cmake tasks in the terminal. Generally set as false
     focus_on_main_terminal = false, -- Focus on cmake terminal when cmake task is launched. Only used if cmake_always_use_terminal is true.
     focus_on_launch_terminal = false, -- Focus on cmake launch terminal when executable target in launched.
+    set_terminal_filetype = true -- For integration for plugins like hardtime.nvim where buffer may need to be scrolled with hjkl keys
   }
 }
 

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -64,6 +64,15 @@ function terminal.new_instance(term_name, opts)
   local new_buffers_list = vim.api.nvim_list_bufs()
   local diff_buffers_list = terminal.symmetric_difference(buffers_before, new_buffers_list)
   terminal.delete_duplicate_terminal_buffers_except(term_name, diff_buffers_list)
+
+  -- This is mainly for users to do filtering if necessary, as termial does not have a default type.
+  -- Example: using a filter in 'hardtime.nvim' to make sure
+  -- we can use chained hjkl keys in sucession in the terminal to scroll.
+  -- It also makes it easier to get the terminals that are unique to cmake_tools
+  if opts.set_terminal_filetype then
+    vim.api.nvim_buf_set_option( vim.api.nvim_get_current_buf(),'filetype', 'cmake_tools_terminal')
+  end
+
   terminal.delete_scratch_buffers()
 
   local new_buffer_idx = terminal.get_buffer_number_from_name(term_name)
@@ -186,12 +195,14 @@ function terminal.create_if_not_exists(term_name, opts)
     end
   end
 
+  local does_terminal_already_exist = false
   if term_idx ~= nil then
-    return true, term_idx
+    does_terminal_already_exist = true
   else
     term_idx = terminal.new_instance(term_name, opts)
-    return false, term_idx
+    -- does_terminal_already_exist terminal will be default (false)
   end
+    return does_terminal_already_exist, term_idx
 end
 
 function terminal.reposition(opts)


### PR DESCRIPTION
This is an option that can be provided for other plugins to integrate with cmake_tools. The scrolling buffer can be simply filtered by searching for 'cmake_tools_terminal' filetype directly. For example, using [`hardtime.nvim`](https://github.com/m4xshen/hardtime.nvim)

Ex:

```lua
-- Setter (done on our side)
vim.api.nvim_buf_set_option(<bufnr>, 'filetype', 'cmake_tools_terminal')

-- Getter (in another plugin. Example: hardtime.nvim)
local ft = vim.api.nvim_buf_get_option(<bufnr>, 'filetype')
```

PS: Can be helpful to eliminate the need to create prefixed named for all cmake terminals if we can filter with file types.