### PR TITLE
Added new terminal filetype for easier filtering of terminal buffers

### DIFF
--- a/docs/howto.md
+++ b/docs/howto.md
@@ -469,6 +469,12 @@ By default, this plugin uses quickfix console for generate, build, clean, instal
 
 But if you want to always use terminal(for example, you want to record all commands and corresponding output), there is a way. You need set `cmake_always_use_terminal` to true, then, all commands will be executed in the terminal.
 
+---
+
+## Integrations
+
+### NvimTree
+
 For users that are using nvim-tree, to keep the size of terminal constant, you should add the following configuration for nvim-tree.
 
 ```lua
@@ -480,4 +486,15 @@ require("nvim-tree").setup {
     },
 }
 ```
-
+### Terminal type buffer filtering (HardTime.nvim)
+When focused on a terminal buffer (not for quickfix-lists, except run terminal), you can check the filetype with `:set ft`. It should display `cmake_tools_terminal`.
+This can be useful for users of plugins like [hardtime.nvim](https://github.com/m4xshen/hardtime.nvim) you can specify the CMake terminal buffers like:
+(Scrolling becomes much easier without having to resort to vim motions like `CTRL H` + `zz` or `CTRL L` + `zz`) in order to scroll the buffer
+```lua
+{
+    "m4xshen/hardtime.nvim",
+    event = "VeryLazy",
+    opts = { disabled_filetypes = { "cmake_tools_terminal" },
+    }
+},
+```

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -42,6 +42,7 @@ local const = {
     start_insert_in_other_tasks = false, -- If you want to enter terminal with :startinsert upon launching all other cmake tasks in the terminal. Generally set as false
     focus_on_main_terminal = false, -- Focus on cmake terminal when cmake task is launched. Only used if cmake_always_use_terminal is true.
     focus_on_launch_terminal = false, -- Focus on cmake launch terminal when executable target in launched.
+    set_terminal_filetype = true -- For integration for plugins like hardtime.nvim where buffer may need to be scrolled with hjkl keys
   }
 }
 

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -42,7 +42,6 @@ local const = {
     start_insert_in_other_tasks = false, -- If you want to enter terminal with :startinsert upon launching all other cmake tasks in the terminal. Generally set as false
     focus_on_main_terminal = false, -- Focus on cmake terminal when cmake task is launched. Only used if cmake_always_use_terminal is true.
     focus_on_launch_terminal = false, -- Focus on cmake launch terminal when executable target in launched.
-    set_terminal_filetype = true -- For integration for plugins like hardtime.nvim where buffer may need to be scrolled with hjkl keys
   }
 }
 

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -69,9 +69,7 @@ function terminal.new_instance(term_name, opts)
   -- Example: using a filter in 'hardtime.nvim' to make sure
   -- we can use chained hjkl keys in sucession in the terminal to scroll.
   -- It also makes it easier to get the terminals that are unique to cmake_tools
-  if opts.set_terminal_filetype then
-    vim.api.nvim_buf_set_option( vim.api.nvim_get_current_buf(),'filetype', 'cmake_tools_terminal')
-  end
+  vim.api.nvim_buf_set_option( vim.api.nvim_get_current_buf(),'filetype', 'cmake_tools_terminal')
 
   terminal.delete_scratch_buffers()
 

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -64,6 +64,15 @@ function terminal.new_instance(term_name, opts)
   local new_buffers_list = vim.api.nvim_list_bufs()
   local diff_buffers_list = terminal.symmetric_difference(buffers_before, new_buffers_list)
   terminal.delete_duplicate_terminal_buffers_except(term_name, diff_buffers_list)
+
+  -- This is mainly for users to do filtering if necessary, as termial does not have a default type.
+  -- Example: using a filter in 'hardtime.nvim' to make sure
+  -- we can use chained hjkl keys in sucession in the terminal to scroll.
+  -- It also makes it easier to get the terminals that are unique to cmake_tools
+  if opts.set_terminal_filetype then
+    vim.api.nvim_buf_set_option( vim.api.nvim_get_current_buf(),'filetype', 'cmake_tools_terminal')
+  end
+
   terminal.delete_scratch_buffers()
 
   local new_buffer_idx = terminal.get_buffer_number_from_name(term_name)
@@ -186,12 +195,14 @@ function terminal.create_if_not_exists(term_name, opts)
     end
   end
 
+  local does_terminal_already_exist = false
   if term_idx ~= nil then
-    return true, term_idx
+    does_terminal_already_exist = true
   else
     term_idx = terminal.new_instance(term_name, opts)
-    return false, term_idx
+    -- does_terminal_already_exist terminal will be default (false)
   end
+    return does_terminal_already_exist, term_idx
 end
 
 function terminal.reposition(opts)


### PR DESCRIPTION
This is an option that can be provided for other plugins to integrate with cmake_tools. The scrolling buffer can be simply filtered by searching for 'cmake_tools_terminal' filetype directly. For example, using [`hardtime.nvim`](https://github.com/m4xshen/hardtime.nvim). You can specify the ignored/included filetypes for specific operations like: 

```lua
{
    "m4xshen/hardtime.nvim",
    event = "VeryLazy",
    opts = { disabled_filetypes = { "cmake_tools_terminal" },
    }
},

```

Ex:

```lua
-- Setter (done on our side)
vim.api.nvim_buf_set_option(<bufnr>, 'filetype', 'cmake_tools_terminal')

-- Getter (in another plugin. Example: hardtime.nvim)
local ft = vim.api.nvim_buf_get_option(<bufnr>, 'filetype')
```

PS: Can be helpful to eliminate the need to create prefixed named for all cmake terminals if we can filter with file types.