### PR TITLE
Session init fixes

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -30,17 +30,19 @@ function cmake.setup(values)
   -- auto reload previous session
   if cmake.is_cmake_project() then
     local old_config = _session.load()
-    config:update_build_dir(old_config.build_directory)
-    config.generate_options = old_config.generate_options
-    config.build_options = old_config.build_options
+    if next(old_config) ~= nil then
+      config:update_build_dir(old_config.build_directory)
+      config.generate_options = old_config.generate_options
+      config.build_options = old_config.build_options
 
-    config.build_type = old_config.build_type
-    config.build_target = old_config.build_target
-    config.launch_target = old_config.launch_target
-    config.launch_args = old_config.launch_args
-    config.kit = old_config.kit
-    config.configure_preset = old_config.configure_preset
-    config.build_preset = old_config.build_preset
+      config.build_type = old_config.build_type
+      config.build_target = old_config.build_target
+      config.launch_target = old_config.launch_target
+      config.launch_args = old_config.launch_args
+      config.kit = old_config.kit
+      config.configure_preset = old_config.configure_preset
+      config.build_preset = old_config.build_preset
+    end
   end
 end
 

--- a/lua/cmake-tools/session.lua
+++ b/lua/cmake-tools/session.lua
@@ -10,28 +10,38 @@ local session = {
   }
 }
 
+local function get_cache_path()
+  if osys.islinux then
+    return session.dir.unix
+  elseif osys.ismac then
+    return session.dir.mac
+  elseif osys.iswsl then
+    return session.dir.unix
+  elseif osys.iswin32 then
+    return session.dir.win
+  end
+end
 
 local function get_current_path()
   local current_path = vim.loop.cwd()
   local clean_path = current_path:gsub("/", "")
+  return get_cache_path() .. clean_path .. ".lua";
+end
 
-  local path;
-
-  if osys.islinux then
-    path = session.dir.unix .. clean_path .. ".lua";
-  elseif osys.ismac then
-    path = session.dir.mac .. clean_path .. ".lua";
-  elseif osys.iswsl then
-    path = session.dir.unix .. clean_path .. ".lua";
-  elseif osys.iswin32 then
-    path = session.dir.win .. clean_path .. ".lua";
+local function init_cache()
+  local cache_path = get_cache_path()
+  if not utils.file_exists(cache_path) then
+    utils.mkdir(cache_path)
   end
+end
 
+local function init_session()
+  init_cache()
+
+  local path = get_current_path()
   if not utils.file_exists(path) then
     os.execute("touch " .. path)
   end
-
-  return path;
 end
 
 function session.load()
@@ -42,6 +52,7 @@ function session.load()
     return config
   end
 
+  init_session()
   return {}
 end
 

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -131,6 +131,11 @@ function utils.has_active_job(always_use_terminal)
   end
 end
 
+function utils.mkdir(dir)
+  local _dir = Path:new(dir)
+  _dir:mkdir({ parents = true, exists_ok = true })
+end
+
 function utils.rmdir(dir)
   local _dir = Path:new(vim.loop.cwd(), dir)
   if _dir:exists() then


### PR DESCRIPTION
First of all, thanks for the session support! Was on my wish list for this plugin.

I got some errors running master tough, related to creation of the cache directory. On Linux the "touch" command fails if the cache directory does not already exist. So I added some code for that in this PR.

Also made sure that if session.load() returned empty table (first time starting new session), we don't overwrite the config with it as that broke stuff.

Commits in this PR resolved stuff for me, but I have not tested for any other OS.