### PR TITLE
OLD PR: Fixed terminal focus issue

### DIFF
--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -169,7 +169,7 @@ function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
     -- do nothing
   end
 
-  if opts and (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
+  if opts and not (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
     vim.cmd("wincmd p") -- Goes back to previous window: Equivalent to [[ CTRL-W w ]]
   elseif opts and opts.start_insert then
     vim.cmd("startinsert")

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -172,6 +172,7 @@ function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
   if opts and not (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
     vim.cmd("wincmd p") -- Goes back to previous window: Equivalent to [[ CTRL-W w ]]
   elseif opts and opts.start_insert then
+    vim.api.nvim_set_current_win(opts.win_id)
     vim.cmd("startinsert")
   end
 

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -174,6 +174,8 @@ function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
   elseif opts and opts.start_insert then
     vim.api.nvim_set_current_win(opts.win_id)
     vim.cmd("startinsert")
+  else
+    vim.api.nvim_set_current_win(opts.win_id)
   end
 
   -- Focus on the last line in the buffer to keep the scrolling output

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -171,7 +171,7 @@ function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
 
   if opts and (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
     vim.cmd("wincmd p") -- Goes back to previous window: Equivalent to [[ CTRL-W w ]]
-  elseif opts and opts.startinsert then
+  elseif opts and opts.start_insert then
     vim.cmd("startinsert")
   end
 


### PR DESCRIPTION
- fixed start insert option upon the launch of the terminal
- fixed inverted focus on terminal option
- fixed: terminal window does not get focused if it already exists
- fixed: terminal does not get focused if start_insert option is disabled
