### PR TITLE
fixed: terminal window focus issues

### DIFF
--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -172,7 +172,10 @@ function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
   if opts and not (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
     vim.cmd("wincmd p") -- Goes back to previous window: Equivalent to [[ CTRL-W w ]]
   elseif opts and opts.start_insert then
+    vim.api.nvim_set_current_win(opts.win_id)
     vim.cmd("startinsert")
+  else
+    vim.api.nvim_set_current_win(opts.win_id)
   end
 
   -- Focus on the last line in the buffer to keep the scrolling output


### PR DESCRIPTION
Fixed terminal focus issues wherein terminal window does not get focused if there is already an existing terminal window and when the start_insert option is disabled
