### PR TITLE
nvim-notify support

### DIFF
--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -42,7 +42,12 @@ local const = {
     start_insert_in_other_tasks = false, -- If you want to enter terminal with :startinsert upon launching all other cmake tasks in the terminal. Generally set as false
     focus_on_main_terminal = false, -- Focus on cmake terminal when cmake task is launched. Only used if cmake_always_use_terminal is true.
     focus_on_launch_terminal = false, -- Focus on cmake launch terminal when executable target in launched.
-  }
+  },
+  cmake_notifications = {
+    enabled = true,                                                 -- show cmake execution progress in nvim-notify
+    spinner = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }, -- icons used for progress display
+    refresh_rate_ms = 100,                                          -- how often to iterate icons
+  },
 }
 
 return const

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -127,6 +127,7 @@ function cmake.generate(opt, callback)
         cmake_launch_path = vim.loop.cwd(),
         cmake_always_use_terminal = const.cmake_always_use_terminal,
         cmake_quickfix_opts = const.cmake_quickfix_opts,
+        cmake_notifications = const.cmake_notifications,
       })
     end
   end
@@ -205,6 +206,7 @@ function cmake.generate(opt, callback)
       cmake_launch_path = vim.loop.cwd(),
       cmake_always_use_terminal = const.cmake_always_use_terminal,
       cmake_quickfix_opts = const.cmake_quickfix_opts,
+      cmake_notifications = const.cmake_notifications,
     })
   end
 end
@@ -248,6 +250,7 @@ function cmake.clean(callback)
       cmake_launch_path = vim.loop.cwd(),
       cmake_always_use_terminal = const.cmake_always_use_terminal,
       cmake_quickfix_opts = const.cmake_quickfix_opts,
+      cmake_notifications = const.cmake_notifications,
     })
   end
 end
@@ -336,6 +339,7 @@ function cmake.build(opt, callback)
       cmake_launch_path = vim.loop.cwd(),
       cmake_always_use_terminal = const.cmake_always_use_terminal,
       cmake_quickfix_opts = const.cmake_quickfix_opts,
+      cmake_notifications = const.cmake_notifications,
     })
   end
 end
@@ -403,8 +407,9 @@ function cmake.install(opt)
   return utils.run(const.cmake_command, {}, args, {
     cmake_launch_path         = vim.loop.cwd(),
     cmake_always_use_terminal = const.cmake_always_use_terminal,
-    cmake_quickfix_opts       = const.cmake_quickfix_opts,
-    cmake_terminal_opts       = const.cmake_terminal_opts
+    cmake_quickfix_opts = const.cmake_quickfix_opts,
+    cmake_terminal_opts = const.cmake_terminal_opts,
+    cmake_notifications = const.cmake_notifications,
   })
 end
 


### PR DESCRIPTION
I added support for [nvim-notify](https://github.com/rcarriga/nvim-notify).
When nvim-notify is installed this add some eyecandy when executing cmake commands that use the quickfix window.
Should pair well with `cmake_quickfix_opts.show  =  "only_on_error"`



[cmake-notify.webm](https://github.com/Civitasv/cmake-tools.nvim/assets/26342294/414a01f1-1b64-4ce1-aee3-945e743c5726)

