### PR TITLE
Allow working directory to specified when running executables

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,7 +17,8 @@ Example for `CMakeSettings`
 return {
   env = {
     VERBOSE = 1,
-  }
+  },
+  working_dir = "${dir.binary}"
 }
 ```
 
@@ -33,9 +34,25 @@ return {
 }
 ```
 
+## variables
+
+The popup window will show available variables and their values.
+
+```lua
+local vars = {
+  dir = {
+    binary = "",
+    build = ""
+  }
+```
+
+These can be used for substitution (see [working_directory](#working_directory)) or directly as lua variables.
+
+## Settings
+
 Following settings are available:
 
-## `env`
+### `env`
 
 Specify environment variables for various tasks.
 Strings and numbers are supported.
@@ -52,7 +69,7 @@ env = {
 | `CMakeSettings`       | :white_check_mark: | environment varaibles for executing cmake commands. These are per default inherit to targets.  |
 | `CMakeTargetSettings` | :white_check_mark: | environment variables for running and debugging targets.    |
 
-## `inherit_base_environment`
+### `inherit_base_environment`
 
 ```lua
   inherit_base_environment = true -- true|false
@@ -63,7 +80,7 @@ env = {
 | `CMakeSettings`       | :x:                | |
 | `CMakeTargetSettings` | :white_check_mark: | Will inherit env various from base settings if set to `true` |
 
-## `args`
+### `args`
 
 Specify additional command line arguments.
 
@@ -75,3 +92,16 @@ Specify additional command line arguments.
 |--------------         | --------------     |  --------------         |
 | `CMakeSettings`       | :x:                | |
 | `CMakeTargetSettings` | :white_check_mark: | command line arguments passed to executable when running or debugging |
+
+### `working_directory`
+
+Specify the working directory in which run and debug commands are executed. Supports substitution commands (`${}`).
+
+```lua
+  working_directory = "${dir.binary}"
+```
+
+| Command               | Supported          | Details                 |
+|--------------         | --------------     |  --------------         |
+| `CMakeSettings`       | :white_check_mark: | Defines the working directory for all targets unless overwritten. |
+| `CMakeTargetSettings` | :white_check_mark: | Sets the working directory just for this target. No default value - Has to be added manually. |

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -23,6 +23,7 @@ local full_cmd = ""
 
 local base_settings_default = {
   env = {},
+  working_dir = "${dir.binary}",
 }
 
 local target_settings_default = {
@@ -452,6 +453,49 @@ function cmake.open()
   )
 end
 
+function cmake.substitute_path(path, vars)
+  for key, value in pairs(vars) do
+    if type(value) == "string" or type(value) == "number" then
+      path = path:gsub("${" .. key .. "}", value)
+    else
+      if next(value) then
+        local prefix = key .. "."
+        for innerkey, innervalue in pairs(value) do
+          if type(innervalue) == "string" or type(innervalue) == "number" then
+            path = path:gsub("${" .. prefix .. innerkey .. "}", innervalue)
+          end
+        end
+      end
+    end
+  end
+
+  return path
+end
+
+function cmake.get_launch_path(target)
+  local model = config:get_code_model_info()[target]
+  local result = config:get_launch_target_from_info(model)
+  local target_path = result.data
+
+  local launch_path = vim.fn.fnamemodify(target_path, ":h")
+
+  if config.base_settings.working_dir and type(config.base_settings.working_dir) == "string" then
+    launch_path =
+      cmake.substitute_path(config.base_settings.working_dir, cmake.get_target_vars(target))
+  end
+
+  if
+    config.target_settings[target]
+    and config.target_settings[target].working_dir
+    and type(config.target_settings[target].working_dir) == "string"
+  then
+    launch_path = config.target_settings[target].working_dir
+    launch_path = cmake.substitute_path(launch_path, cmake.get_target_vars(target))
+  end
+
+  return launch_path
+end
+
 -- Run executable targets
 function cmake.run(opt)
   if utils.has_active_job(const.cmake_always_use_terminal) then
@@ -465,7 +509,7 @@ function cmake.run(opt)
       local result = config:get_launch_target_from_info(model)
       local target_path = result.data
 
-      local launch_path = vim.fn.fnamemodify(target_path, ":h")
+      local launch_path = cmake.get_launch_path(opt.target)
 
       if full_cmd ~= "" then
         full_cmd = 'cd "'
@@ -524,7 +568,8 @@ function cmake.run(opt)
       return cmake.build({ fargs = utils.deepcopy(opt.fargs) }, function()
         result = config:get_launch_target()
         local target_path = result.data
-        local launch_path = vim.fn.fnamemodify(target_path, ":h")
+
+        local launch_path = cmake.get_launch_path(cmake.get_launch_target())
 
         if full_cmd ~= "" then
           -- This jumps to the working directory, builds the target and then launches it inside the launch terminal
@@ -682,7 +727,7 @@ if has_nvim_dap then
         local dap_config = {
           name = opt.target,
           program = result.data,
-          cwd = utils.get_path(result.data, "/"),
+          cwd = cmake.get_launch_path(opt.target),
           args = opt.args,
           env = env,
         }
@@ -724,7 +769,7 @@ if has_nvim_dap then
           local dap_config = {
             name = config.launch_target,
             program = target_path,
-            cwd = utils.get_path(result.data, "/"),
+            cwd = cmake.get_launch_path(cmake.get_launch_target()),
             args = cmake:get_launch_args(),
             env = env,
           }
@@ -1039,6 +1084,23 @@ function cmake.select_launch_target(callback, regenerate)
   )
 end
 
+function cmake.get_base_vars()
+  local vars = { dir = {} }
+
+  vars.dir.build = config.build_directory.filename .. "/"
+  vars.dir.binary = "${dir.binary}"
+  return vars
+end
+
+function cmake.get_target_vars(target)
+  local vars = cmake.get_base_vars()
+
+  local model = config:get_code_model_info()[target]
+  local result = config:get_launch_target_from_info(model)
+  vars.dir.binary = utils.get_path(result.data, "/") .. "/"
+  return vars
+end
+
 function cmake.settings()
   if not window.is_open() then
     if not config.base_settings then
@@ -1048,7 +1110,10 @@ function cmake.settings()
     -- insert missing fields
     config.base_settings = vim.tbl_deep_extend("keep", config.base_settings, base_settings_default)
 
-    window.set_content("return " .. vim.inspect(config.base_settings))
+    local content = "local vars = " .. vim.inspect(cmake.get_base_vars())
+    content = content .. "\nreturn" .. vim.inspect(config.base_settings)
+
+    window.set_content(content)
     window.title = "CMake-Tools base settings"
     window.on_save = function(str)
       local fn = loadstring(str)
@@ -1080,7 +1145,10 @@ function cmake.target_settings(opt)
     config.target_settings[target] =
       vim.tbl_deep_extend("keep", config.target_settings[target], target_settings_default)
 
-    window.set_content("return " .. vim.inspect(config.target_settings[target]))
+    local content = "local vars = " .. vim.inspect(cmake.get_target_vars(target))
+    content = content .. "\nreturn" .. vim.inspect(config.target_settings[target])
+
+    window.set_content(content)
     window.title = "CMake-Tools settings for " .. target
     window.on_save = function(str)
       local fn = loadstring(str)

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -440,7 +440,7 @@ end
 
 function terminal.prepare_cmd_for_execute(executable, args, launch_path, wrap_call, env)
   local full_cmd = ""
-  executable = vim.fn.fnamemodify(executable, ":t")
+  -- executable = vim.fn.fnamemodify(executable, ":t")
 
   -- Launch form executable's build directory by default
   launch_path = terminal.prepare_launch_path(launch_path)
@@ -463,11 +463,8 @@ function terminal.prepare_cmd_for_execute(executable, args, launch_path, wrap_ca
 
   full_cmd = full_cmd .. " "
 
-  if osys.iswin32 then
-    -- Weird windows thing: executables that are not in path only work as ".\executable" and not "executable" on the cmdline (even if focus is in the same directory)
-    full_cmd = full_cmd .. ".\\"
-  elseif osys.islinux or osys.iswsl or osys.ismac then
-    full_cmd = " " .. full_cmd .. "./" -- adding a space in front of the command prevents bash from recording the command in the history (if configured)
+  if osys.islinux or osys.iswsl or osys.ismac then
+    full_cmd = " " .. full_cmd -- adding a space in front of the command prevents bash from recording the command in the history (if configured)
   end
 
   full_cmd = full_cmd .. executable


### PR DESCRIPTION
See https://github.com/Civitasv/cmake-tools.nvim/issues/100

It now always runs executeables with absolute path. But this should be ok.