### PR TITLE
Remove goto statements to ensure compatibility with (plain) Lua 5.1

### DIFF
--- a/lua/cmake-tools/environment.lua
+++ b/lua/cmake-tools/environment.lua
@@ -36,9 +36,7 @@ local function unroll(env, escape)
       table.insert(res, var)
     else
       -- unsupported type
-      goto ignore
     end
-    ::ignore::
   end
 
   return res

--- a/lua/cmake-tools/file_picker.lua
+++ b/lua/cmake-tools/file_picker.lua
@@ -18,22 +18,11 @@ function M.get_files_from_target(target)
   if info.sourceGroups then
     for _, v in ipairs(info.sourceGroups) do
       -- ignore cerain files such as .o/.obj files and cmake rules
-
-      if v.name == "CMake Rules" then
-        goto skip
-      end
-
-      if v.name == "Object Libraries" then
-        goto skip
-      end
-
-      if v.sourceIndexes then
+      if not (v.name == "CMake Rules" or v.name == "Object Libraries") and v.sourceIndexes then
         for _, srcIdx in ipairs(v.sourceIndexes) do
           table.insert(files, info.sources[srcIdx + 1].path) -- +1 because lua is 1 indexed
         end
       end
-
-      ::skip::
     end
   end
 
@@ -77,22 +66,15 @@ function M.get_cmake_files()
   end
 
   for _, v in pairs(cmakeFiles.data) do
-    if v.isCMake and v.isCMake == true then
-      -- ignore standard cmake files such as "CMakeCommonLanguageInclude"
-      goto skip
-    end
-
-    if v.isGenerated and v.isGenerated == true then
-      -- ignore generated files such as "CMakeCXXCompiler"
-      goto skip
-    end
-
-    if v.path then
+    -- ignore standard cmake files such as "CMakeCommonLanguageInclude"
+    -- ignore generated files such as "CMakeCXXCompiler"
+    if not ( 
+        (v.isCMake and v.isCMake == true) 
+        or (v.isGenerated and v.isGenerated == true) 
+      ) and v.path then
       -- use files as keys to prevent duplicates (there can be quite a few when using package managers)
       files[v.path] = 1
     end
-
-    ::skip::
   end
 
   -- convert set to list

--- a/lua/cmake-tools/file_picker.lua
+++ b/lua/cmake-tools/file_picker.lua
@@ -68,10 +68,10 @@ function M.get_cmake_files()
   for _, v in pairs(cmakeFiles.data) do
     -- ignore standard cmake files such as "CMakeCommonLanguageInclude"
     -- ignore generated files such as "CMakeCXXCompiler"
-    if not ( 
-        (v.isCMake and v.isCMake == true) 
-        or (v.isGenerated and v.isGenerated == true) 
-      ) and v.path then
+    if
+      not ((v.isCMake and v.isCMake == true) or (v.isGenerated and v.isGenerated == true))
+      and v.path
+    then
       -- use files as keys to prevent duplicates (there can be quite a few when using package managers)
       files[v.path] = 1
     end

--- a/lua/simpleyaml.lua
+++ b/lua/simpleyaml.lua
@@ -78,50 +78,48 @@ function simpleyaml.parse_file(path)
   for line in file:lines() do -- for all lines in the file
     -- goto next line if current line is empty, a comment, the document start, or a directive
     if
-      line:gsub("%s*", "") == ""
-      or line:find("^#") ~= nil
-      or line:find("^---") ~= nil
-      or line:find("^%%") ~= nil
-    then
-      goto cont_processing_lines
-    end
+      not (
+        line:gsub("%s*", "") == ""
+        or line:find("^#") ~= nil
+        or line:find("^---") ~= nil
+        or line:find("^%%") ~= nil
+      ) then
+    
+      local indent = line:match("(%s*)%S.*"):len() -- get indent of current line
+      if #indents > 0 then -- if stack of indents not empty
+        local prevIndent = indents[#indents]
 
-    local indent = line:match("(%s*)%S.*"):len() -- get indent of current line
-    if #indents > 0 then -- if stack of indents not empty
-      local prevIndent = indents[#indents]
-
-      -- compare with indent of previous line
-      if indent > prevIndent then -- if current indent larger, increase nesting level
-        nestingLevel = nestingLevel + 1
-      elseif indent < prevIndent then -- of current indent smaller, decrease nesting level and ...
-        nestingLevel = nestingLevel - 1
-        while indents[#indents] > indent do -- ... clean up the stack of indents, tracking the nesting level
-          if prevIndent < indents[#indents] then
-            nestingLevel = nestingLevel + 1
-          elseif prevIndent > indents[#indents] then
-            nestingLevel = nestingLevel - 1
+        -- compare with indent of previous line
+        if indent > prevIndent then -- if current indent larger, increase nesting level
+          nestingLevel = nestingLevel + 1
+        elseif indent < prevIndent then -- of current indent smaller, decrease nesting level and ...
+          nestingLevel = nestingLevel - 1
+          while indents[#indents] > indent do -- ... clean up the stack of indents, tracking the nesting level
+            if prevIndent < indents[#indents] then
+              nestingLevel = nestingLevel + 1
+            elseif prevIndent > indents[#indents] then
+              nestingLevel = nestingLevel - 1
+            end
+            prevIndent = indents[#indents]
+            table.remove(indents)
           end
-          prevIndent = indents[#indents]
-          table.remove(indents)
         end
       end
-    end
-    table.insert(indents, indent) -- insert current indent into stack
+      table.insert(indents, indent) -- insert current indent into stack
 
-    local key = line:match("%s*(.*):") -- read the key from the line (everything before ':')
-    if key == "" then -- no key found, error
-      return nil
-    end
-    insertKey(key, nestingLevel, parsed) -- insert the key
+      local key = line:match("%s*(.*):") -- read the key from the line (everything before ':')
+      if key == "" then -- no key found, error
+        return nil
+      end
+      insertKey(key, nestingLevel, parsed) -- insert the key
 
-    line = line:match(":%s*(.*)%s*") -- read rest of the line (everything after ':')
-    -- if there is something, insert the rest of the line as a string value
-    -- otherwise, the value is an object, so go ahead to read next line
-    if line:len() > 0 then
-      insertString(line, nestingLevel, parsed)
+      line = line:match(":%s*(.*)%s*") -- read rest of the line (everything after ':')
+      -- if there is something, insert the rest of the line as a string value
+      -- otherwise, the value is an object, so go ahead to read next line
+      if line:len() > 0 then
+        insertString(line, nestingLevel, parsed)
+      end
     end
-
-    ::cont_processing_lines::
   end
 
   file:close()

--- a/lua/simpleyaml.lua
+++ b/lua/simpleyaml.lua
@@ -83,8 +83,8 @@ function simpleyaml.parse_file(path)
         or line:find("^#") ~= nil
         or line:find("^---") ~= nil
         or line:find("^%%") ~= nil
-      ) then
-    
+      )
+    then
       local indent = line:match("(%s*)%S.*"):len() -- get indent of current line
       if #indents > 0 then -- if stack of indents not empty
         local prevIndent = indents[#indents]


### PR DESCRIPTION
Neovim is generally used with LuaJIT which [offers a set of extensions over Lua 5.1](http://luajit.org/extensions.html), including `goto`. However, Neovim can also be [built using plain Lua 5.1](https://github.com/neovim/neovim/blob/0211f889b9538f7df5fbcb06273d273fb071efff/cmake.deps/deps.txt#L10C1-L10C49). To allow the use of Neovim and cmake-tools.nvim on ISA's which are not supported by LuaJIT, it would be useful to keep the code compatible to plain Lua.

This PR removes all usages of `goto` and replaces them with simple conditionals.