### PR TITLE
Fixed preset.decode creating wrong preset paths

### DIFF
--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -73,7 +73,7 @@ local function decode(file)
   end
 
   for _, f in ipairs(includes) do
-    local fdata = vim.fn.json_decode(vim.fn.readfile(vim.fs.dirname(file) .. "/" .. f))
+    local fdata = vim.fn.json_decode(vim.fn.readfile(f))
     local thisFilePresetKeys = vim.tbl_filter(function(key)
       if string.find(key, "Presets") then
         return true

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -59,12 +59,15 @@ local function decode(file)
   local isUserPreset = string.find(file:lower(), "user")
   if #includes == 0 and isUserPreset then
     local parentDir = vim.fs.dirname(file)
-    local parentPreset = parentDir .. "/CMakePresets.json"
-    local parentPresetKebapCase = parentDir .. "/cmake-presets.json"
-    if vim.fn.filereadable(parentPreset) then
-      includes[#includes + 1] = parentPreset
-    elseif vim.fn.filereadable(parentPresetKebapCase) then
-      includes[#includes + 1] = parentPresetKebapCase
+    local preset = "CMakePresets.json"
+    local presetKebapCase = "cmake-presets.json"
+    local presetPath = parentDir .. "/" .. preset
+    local presetKebapCasePath = parentDir .. "/" .. presetKebapCase
+
+    if vim.fn.filereadable(presetPath) then
+      includes[#includes + 1] = preset
+    elseif vim.fn.filereadable(presetKebapCasePath) then
+      includes[#includes + 1] = presetKebapCase
     end
   end
 
@@ -73,7 +76,7 @@ local function decode(file)
   end
 
   for _, f in ipairs(includes) do
-    local fdata = vim.fn.json_decode(vim.fn.readfile(f))
+    local fdata = vim.fn.json_decode(vim.fn.readfile(vim.fs.dirname(file) .. "/" .. f))
     local thisFilePresetKeys = vim.tbl_filter(function(key)
       if string.find(key, "Presets") then
         return true


### PR DESCRIPTION
The path will be concatenated twice as the includes will already contain the parent path.
(See #129)
