### PR TITLE
Fix compile_commands.json soft link creation

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1294,10 +1294,7 @@ function cmake.compile_commands_from_soft_link()
     return
   end
 
-  local source = config.working_dir
-    .. "/"
-    .. config.build_directory.filename
-    .. "/compile_commands.json"
+  local source = config.build_directory.filename .. "/compile_commands.json"
   local destination = vim.loop.cwd() .. "/compile_commands.json"
   if config.always_use_terminal or utils.file_exists(source) then
     utils.softlink(source, destination, config.always_use_terminal, config.terminal.opts)


### PR DESCRIPTION
Right now, the absolute working_dir path is concatenated again with the absolute build_directory path, which results in an invalid file path and the symlink not being created. The build_directory will be already an absolute path being constructed using the working_dir.