### PR TITLE
Fix compatibility with windows path

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1133,7 +1133,7 @@ function cmake.get_target_vars(target)
 
   local model = config:get_code_model_info()[target]
   local result = config:get_launch_target_from_info(model)
-  vars.dir.binary = utils.get_path(result.data, "/") .. "/"
+  vars.dir.binary = utils.get_path(result.data) .. '/'
   return vars
 end
 

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1133,7 +1133,7 @@ function cmake.get_target_vars(target)
 
   local model = config:get_code_model_info()[target]
   local result = config:get_launch_target_from_info(model)
-  vars.dir.binary = utils.get_path(result.data) .. '/'
+  vars.dir.binary = utils.get_path(result.data) .. "/"
   return vars
 end
 

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -1,4 +1,5 @@
 local Path = require("plenary.path")
+local osys = require("cmake-tools.osys")
 local Result = require("cmake-tools.result")
 local Types = require("cmake-tools.types")
 local terminal = require("cmake-tools.executors.terminal")
@@ -55,7 +56,7 @@ function utils.close_cmake_window(executor_data)
 end
 
 function utils.get_path(str, sep)
-  sep = sep or "/"
+  sep = sep or (osys.iswin32 and "\\" or "/")
   return str:match("(.*" .. sep .. ")")
 end
 


### PR DESCRIPTION
the paths on windows are `\` yet the  `get_path` function used the `/` seperator.