### PR TITLE
Setting cwd with command args

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1317,6 +1317,10 @@ function cmake.select_cwd()
   )
 end
 
+function cmake.select_cwd_given(cwd_path)
+  config.cwd = vim.fn.resolve(cwd_path)
+end
+
 function cmake.create_regenerate_on_save_autocmd()
   if not const.cmake_regenerate_on_save then
     return

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1301,24 +1301,24 @@ end
 local group = vim.api.nvim_create_augroup("cmaketools", { clear = true })
 local regenerate_id = nil
 
-function cmake.select_cwd()
-  vim.ui.input(
-    {
-      prompt = "The directory where the main CMakeLists.txt is located",
-      default = vim.loop.cwd(),
-      completion = "dir",
-    },
-    vim.schedule_wrap(function(input)
-      --local new_path = Path:new(input)
-      --if new_path:is_dir() then
-      config.cwd = vim.fn.resolve(input)
-      --	end
-    end)
-  )
-end
-
-function cmake.select_cwd_given(cwd_path)
-  config.cwd = vim.fn.resolve(cwd_path)
+function cmake.select_cwd(cwd_path)
+  if cwd_path.args == nil then
+    vim.ui.input(
+      {
+        prompt = "The directory where the main CMakeLists.txt is located",
+        default = vim.loop.cwd(),
+        completion = "dir",
+      },
+      vim.schedule_wrap(function(input)
+        --local new_path = Path:new(input)
+        --if new_path:is_dir() then
+        config.cwd = vim.fn.resolve(input)
+        --	end
+      end)
+    )
+  elseif cwd_path.args then
+    config.cwd = vim.fn.resolve(cwd_path.args)
+  end
 end
 
 function cmake.create_regenerate_on_save_autocmd()

--- a/plugin/cmake-tools.lua
+++ b/plugin/cmake-tools.lua
@@ -234,3 +234,13 @@ vim.api.nvim_create_user_command(
     desc = "CMake select cwd",
   }
 )
+
+--- CMake select cwd with arguments
+vim.api.nvim_create_user_command(
+  "CMakeSelectCwdArgs",
+  cmake_tools.select_cwd_given,
+  { -- opts
+    nargs = 1,
+    desc = "CMake select cwd",
+  }
+)

--- a/plugin/cmake-tools.lua
+++ b/plugin/cmake-tools.lua
@@ -230,17 +230,7 @@ vim.api.nvim_create_user_command(
   "CMakeSelectCwd", -- name
   cmake_tools.select_cwd, -- command
   { -- opts
-    nargs = 0,
-    desc = "CMake select cwd",
-  }
-)
-
---- CMake select cwd with arguments
-vim.api.nvim_create_user_command(
-  "CMakeSelectCwdArgs",
-  cmake_tools.select_cwd_given,
-  { -- opts
-    nargs = 1,
+    nargs = "?",
     desc = "CMake select cwd",
   }
 )


### PR DESCRIPTION
The CMakeSelectCwd command now accepts an optional argument which, if given, will set the CWD to the path of the arg. If no argument is given, the previous behavior applies.