### PR TITLE
Fix broken build directory in session

### DIFF
--- a/lua/cmake-tools/session.lua
+++ b/lua/cmake-tools/session.lua
@@ -64,8 +64,13 @@ function session.save(config)
   local path = get_current_path()
   local file = io.open(path, "w")
 
+  local serialized_build_directory = ""
+  if config.build_directory then
+    serialized_build_directory = config.build_directory:make_relative(config.cwd)
+  end
+
   local serialized_object = {
-    build_directory = config.build_directory and config.build_directory.filename or "",
+    build_directory = serialized_build_directory,
     build_type = config.build_type,
     build_target = config.build_target,
     launch_target = config.launch_target,


### PR DESCRIPTION
When a session is loaded, it is assumed that
the build directory path is relative to the
project/cwd. However, when the session is saved,
then the build directory is serialized as an
absolute path. This caused the resulting path to
be "project root" + "full path to build directory":

/path/to/project//path/to/project/build/

This fixes the issue by serializing the build
directory as relative the project root.