### PR TITLE
Experimental: Env Setup Script for terminal

### DIFF
--- a/docs/cmake_kits.md
+++ b/docs/cmake_kits.md
@@ -30,6 +30,7 @@ An Example:
     "name": "VS 17 2022 amd64",
     "generator": "Visual Studio 17 2022",
     "host_architecture": "x64",
+    "environmentSetupScript": "& \"C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat\"",
     "target_architecture": "x64",
     "compilers": {
       "C": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe",
@@ -51,4 +52,4 @@ You can also define general global kits in somewhere. To do this, you will have 
 2. Option `visualStudio` and `visualStudioArchitecture` is not supported.
 3. Option `preferredGenerator` is not supported.
 4. Option `cmakeSettings` is not supported.
-5. Option `environmentSetupScript` is not supported.
+5. Option `environmentSetupScript` is only supported in the experimental terminal mode.

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -20,11 +20,12 @@ local Config = {
     working_dir = "${dir.binary}",
     generate_options = {},
     build_options = {},
-  }, -- general config
+  },                    -- general config
   target_settings = {}, -- target specific config
   executor = nil,
   terminal = nil,
   always_use_terminal = false,
+  env_script = " ",
   cwd = vim.loop.cwd(),
 }
 

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -20,7 +20,7 @@ local Config = {
     working_dir = "${dir.binary}",
     generate_options = {},
     build_options = {},
-  },                    -- general config
+  }, -- general config
   target_settings = {}, -- target specific config
   executor = nil,
   terminal = nil,

--- a/lua/cmake-tools/executors/overseer.lua
+++ b/lua/cmake-tools/executors/overseer.lua
@@ -14,9 +14,9 @@ function overseer_executor.close(opts)
   overseer.close()
 end
 
-function overseer_executor.run(cmd, env, args, cwd, opts, on_exit, on_output)
+function overseer_executor.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output)
   opts = vim.tbl_extend("keep", {
-    cmd = cmd,
+    cmd = env_script .. " & " .. cmd,
     args = args,
     env = env,
     cwd = cwd,

--- a/lua/cmake-tools/executors/terminal.lua
+++ b/lua/cmake-tools/executors/terminal.lua
@@ -185,7 +185,7 @@ function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
     local type = vim.api.nvim_get_option_value("buftype", {
       buf = buffer_idx,
     })
-    if type ~= "terminal" then
+    if type == "terminal" then
       vim.cmd("normal! G")
     end
   end)

--- a/lua/cmake-tools/executors/terminal.lua
+++ b/lua/cmake-tools/executors/terminal.lua
@@ -545,7 +545,7 @@ function terminal.run(cmd, env_script, env, args, cwd, opts)
   --- NOTE: env_script needs to be run only once if the terminal buffer does not already exist
   --- We compare the old and the new id and only if they are not the same, plus if the terminal exists,
   --    only then, we do not reinitialize the environment, else we reinit the env
-  if terminal_already_exists or terminal.id_old ~= terminal.id then
+  if not terminal_already_exists or terminal.id_old ~= terminal.id then
     terminal.id_old = terminal.id
     terminal.send_data_to_terminal(buffer_idx, env_script, {
       win_id = final_win_id,

--- a/lua/cmake-tools/executors/terminal.lua
+++ b/lua/cmake-tools/executors/terminal.lua
@@ -171,7 +171,7 @@ function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
     -- do nothing
   end
 
-  if opts and not (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
+  if opts and (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
     vim.cmd("wincmd p") -- Goes back to previous window: Equivalent to [[ CTRL-W w ]]
   elseif opts and opts.start_insert then
     vim.api.nvim_set_current_win(opts.win_id)

--- a/lua/cmake-tools/executors/terminal.lua
+++ b/lua/cmake-tools/executors/terminal.lua
@@ -185,14 +185,12 @@ function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
     local name = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(0))
     local basename = vim.fn.fnamemodify(name, ":t")
     if opts and (basename:sub(1, #opts.prefix) == opts.prefix) then -- If currently focused buffer is cmake buffer then ...
-
       -- Now we check again if the buffer needs to be focused as the user might be scrolling
       -- a cmake buffer and execute a :CMakeCommand, so we do not want to move their
       -- cursor out of the cmake buffer, as it can be annoying
       if opts and (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
         vim.cmd("wincmd p") -- Goes back to previous window: Equivalent to [[ CTRL-W p ]]
       end
-
     end
   end
 

--- a/lua/cmake-tools/executors/terminal.lua
+++ b/lua/cmake-tools/executors/terminal.lua
@@ -3,8 +3,8 @@ local log = require("cmake-tools.log")
 
 ---@class terminal:executor
 local terminal = {
-  id = nil,    -- id for the unified terminal
-  id_old = nil -- Old id to keep track of the buffer
+  id = nil, -- id for the unified terminal
+  id_old = nil, -- Old id to keep track of the buffer
 }
 
 function terminal.has_active_job(opts)
@@ -59,8 +59,8 @@ function terminal.new_instance(term_name, opts)
   -- Now create the plit
   vim.cmd(":" .. opts.split_direction .. " " .. opts.split_size .. "sp | :term") -- Creater terminal in a split
   -- local new_name = vim.fn.fnamemodify(term_name, ":t")                           -- Extract only the terminal name and reassign it
-  vim.api.nvim_buf_set_name(vim.api.nvim_get_current_buf(), term_name)           -- Set the buffer name
-  vim.cmd(":setlocal laststatus=3")                                              -- Let there be a single status/lualine in the neovim instance
+  vim.api.nvim_buf_set_name(vim.api.nvim_get_current_buf(), term_name) -- Set the buffer name
+  vim.cmd(":setlocal laststatus=3") -- Let there be a single status/lualine in the neovim instance
 
   -- Renamming a terminal buffer creates a new hidden buffer, so duplicate terminals need to be deleted
   local new_buffers_list = vim.api.nvim_list_bufs()
@@ -248,10 +248,10 @@ function terminal.reposition(opts)
   local final_win_id = -1 -- If -1, then a new window needs to be created, otherwise, we must return an existing winid
   if single_terminal_per_instance then
     if static_window_location then
-      terminal.close_window_from_tabs_with_prefix(true, opts)                             -- Close all cmake windows in all other tabs
+      terminal.close_window_from_tabs_with_prefix(true, opts) -- Close all cmake windows in all other tabs
       local buflist = terminal.check_if_cmake_buffers_are_displayed_across_all_tabs(opts) -- Get list of all buffers that are displayed in current tab
       if next(buflist) then
-        for i = 1, #buflist do                                                            -- Buffers exist in current tab, so close all except first buffer in buflist
+        for i = 1, #buflist do -- Buffers exist in current tab, so close all except first buffer in buflist
           if i > 1 then
             vim.api.nvim_win_close(buflist[i], false)
           end
@@ -259,7 +259,7 @@ function terminal.reposition(opts)
         final_win_id = buflist[1]
       end
     else
-      terminal.close_window_from_tabs_with_prefix(true, opts)                             -- Close all cmake windows in all tabs
+      terminal.close_window_from_tabs_with_prefix(true, opts) -- Close all cmake windows in all tabs
       local buflist = terminal.check_if_cmake_buffers_are_displayed_across_all_tabs(opts) -- Get list of all buffers that are displayed in current tab
       if next(buflist) then
         -- Buffers exist in current tab, so close all buffers in buflist
@@ -545,7 +545,7 @@ function terminal.run(cmd, env_script, env, args, cwd, opts)
   --- NOTE: env_script needs to be run only once if the terminal buffer does not already exist
   --- We compare the old and the new id and only if they are not the same, plus if the terminal exists,
   --    only then, we do not reinitialize the environment, else we reinit the env
-  if not terminal_already_exists or terminal.id_old ~= terminal.id then
+  if terminal_already_exists or terminal.id_old ~= terminal.id then
     terminal.id_old = terminal.id
     terminal.send_data_to_terminal(buffer_idx, env_script, {
       win_id = final_win_id,

--- a/lua/cmake-tools/executors/terminal.lua
+++ b/lua/cmake-tools/executors/terminal.lua
@@ -450,7 +450,6 @@ function terminal.prepare_cmd_for_execute(executable, args, launch_path, wrap_ca
   -- executable = vim.fn.fnamemodify(executable, ":t")
 
   -- Launch form executable's build directory by default
-  launch_path = terminal.prepare_launch_path(launch_path)
   full_cmd = "cd " .. launch_path .. " &&"
 
   if osys.iswin32 then
@@ -471,8 +470,7 @@ function terminal.prepare_cmd_for_execute(executable, args, launch_path, wrap_ca
   full_cmd = full_cmd .. " "
 
   if osys.islinux or osys.iswsl or osys.ismac then
-    full_cmd = " " ..
-        full_cmd -- adding a space in front of the command prevents bash from recording the command in the history (if configured)
+    full_cmd = " " .. full_cmd -- adding a space in front of the command prevents bash from recording the command in the history (if configured)
   end
 
   full_cmd = full_cmd .. executable
@@ -545,8 +543,8 @@ function terminal.run(cmd, env_script, env, args, cwd, opts)
   local final_win_id = terminal.reposition(opts)
 
   --- NOTE: env_script needs to be run only once if the terminal buffer does not already exist
-  --- We compare the old and the new id and only if they are same, plus if the terminal exists, only then
-  ---   we do not reinitialize the environment, else we reinit the env
+  --- We compare the old and the new id and only if they are not the same, plus if the terminal exists,
+  --    only then, we do not reinitialize the environment, else we reinit the env
   if not terminal_already_exists or terminal.id_old ~= terminal.id then
     terminal.id_old = terminal.id
     terminal.send_data_to_terminal(buffer_idx, env_script, {

--- a/lua/cmake-tools/executors/terminal.lua
+++ b/lua/cmake-tools/executors/terminal.lua
@@ -176,10 +176,9 @@ function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
   if opts and (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
     -- We want to focus on the newly set terminal
     vim.api.nvim_set_current_win(opts.win_id)
-  elseif opts and opts.start_insert then
-    -- We want to focus on the newly set terminal and enter start_insert
-    vim.api.nvim_set_current_win(opts.win_id)
-    vim.cmd("startinsert")
+    if opts.start_insert then
+      vim.cmd("startinsert")
+    end
   else
     -- We want to focus on our currently focused window and not ther cmake terminal
     local name = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(0))
@@ -188,7 +187,7 @@ function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
       -- Now we check again if the buffer needs to be focused as the user might be scrolling
       -- a cmake buffer and execute a :CMakeCommand, so we do not want to move their
       -- cursor out of the cmake buffer, as it can be annoying
-      if opts and (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
+      if opts and not (opts.focus_on_launch_terminal or opts.focus_on_main_terminal) then
         vim.cmd("wincmd p") -- Goes back to previous window: Equivalent to [[ CTRL-W p ]]
       end
     end

--- a/lua/cmake-tools/executors/types.lua
+++ b/lua/cmake-tools/executors/types.lua
@@ -13,6 +13,7 @@ function executor.close(opts) end
 
 ---Run a commond
 ---@param cmd string the executable to execute
+---@param env_script string environment setup script
 ---@param env table environment variables
 ---@param args table arguments to the executable
 ---@param cwd string the directory to run in
@@ -20,7 +21,7 @@ function executor.close(opts) end
 ---@param on_exit nil|function extra arguments, f.e on_exit is a callback to be called when the process finishes with the error code
 ---@param on_output nil|function extra arguments, f.e on_output is a callback to be called when the process has new output
 ---@return nil
-function executor.run(cmd, env, args, cwd, opts, on_exit, on_output) end
+function executor.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output) end
 
 ---Checks if there is an active job
 ---@param opts table options for this adapter

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -241,7 +241,7 @@ function cmake.generate(opt, callback)
 
   local args = {
     "-B",
-    '"' .. config.build_directory.filename .. '"',
+    config.build_directory.filename ,
     "-S",
     ".",
   }
@@ -389,7 +389,7 @@ function cmake.build(opt, callback)
   if presets_file and config.build_preset then
     args = { "--build", "--preset", config.build_preset } -- preset don't need define build dir.
   else
-    args = { "--build", '"' .. config.build_directory.filename .. '"' }
+    args = { "--build", config.build_directory.filename }
   end
 
   vim.list_extend(args, config:build_options())
@@ -499,7 +499,7 @@ function cmake.install(opt)
 
   local fargs = opt.fargs
 
-  local args = { "--install", '"' .. config.build_directory.filename .. '"' }
+  local args = { "--install", config.build_directory.filename }
   vim.list_extend(args, fargs)
   return utils.run(
     const.cmake_command,

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -75,7 +75,7 @@ function cmake.setup(values)
       config.cwd = old_config.cwd or vim.loop.cwd()
 
       config.base_settings =
-          vim.tbl_deep_extend("keep", old_config.base_settings, config.base_settings)
+        vim.tbl_deep_extend("keep", old_config.base_settings, config.base_settings)
       config.target_settings = old_config.target_settings or {}
 
       -- migrate old launch args to new config
@@ -158,27 +158,45 @@ function cmake.generate(opt, callback)
     if config.always_use_terminal then
       if full_cmd ~= "" then
         full_cmd = full_cmd
-            .. " && "
-            .. terminal.prepare_cmd_for_run(const.cmake_command, env, args)
+          .. " && "
+          .. terminal.prepare_cmd_for_run(const.cmake_command, env, args)
       else
         full_cmd = terminal.prepare_cmd_for_run(const.cmake_command, env, args)
       end
       if type(callback) == "function" then
         callback()
       else
-        utils.run(full_cmd, config.env_script, {}, {}, config.cwd, config.executor, nil, const.cmake_notifications)
+        utils.run(
+          full_cmd,
+          config.env_script,
+          {},
+          {},
+          config.cwd,
+          config.executor,
+          nil,
+          const.cmake_notifications
+        )
         cmake.configure_compile_commands()
         cmake.create_regenerate_on_save_autocmd()
         full_cmd = ""
       end
     else
-      return utils.run(const.cmake_command, config.env_script, env, args, config.cwd, config.executor, function()
-        if type(callback) == "function" then
-          callback()
-        end
-        cmake.configure_compile_commands()
-        cmake.create_regenerate_on_save_autocmd()
-      end, const.cmake_notifications)
+      return utils.run(
+        const.cmake_command,
+        config.env_script,
+        env,
+        args,
+        config.cwd,
+        config.executor,
+        function()
+          if type(callback) == "function" then
+            callback()
+          end
+          cmake.configure_compile_commands()
+          cmake.create_regenerate_on_save_autocmd()
+        end,
+        const.cmake_notifications
+      )
     end
   end
 
@@ -223,7 +241,7 @@ function cmake.generate(opt, callback)
 
   local args = {
     "-B",
-    config.build_directory.filename,
+    '"' .. config.build_directory.filename .. '"',
     "-S",
     ".",
   }
@@ -243,20 +261,38 @@ function cmake.generate(opt, callback)
     if type(callback) == "function" then
       callback()
     else
-      utils.run(full_cmd, config.env_script, {}, {}, config.cwd, config.executor, nil, const.cmake_notifications)
+      utils.run(
+        full_cmd,
+        config.env_script,
+        {},
+        {},
+        config.cwd,
+        config.executor,
+        nil,
+        const.cmake_notifications
+      )
       cmake.configure_compile_commands()
       cmake.create_regenerate_on_save_autocmd()
       full_cmd = ""
     end
   else
     env = vim.tbl_extend("keep", env, kit_option.env)
-    utils.run(const.cmake_command, config.env_script, env, args, config.cwd, config.executor, function()
-      if type(callback) == "function" then
-        callback()
-      end
-      cmake.configure_compile_commands()
-      cmake.create_regenerate_on_save_autocmd()
-    end, const.cmake_notifications)
+    utils.run(
+      const.cmake_command,
+      config.env_script,
+      env,
+      args,
+      config.cwd,
+      config.executor,
+      function()
+        if type(callback) == "function" then
+          callback()
+        end
+        cmake.configure_compile_commands()
+        cmake.create_regenerate_on_save_autocmd()
+      end,
+      const.cmake_notifications
+    )
   end
 end
 
@@ -271,7 +307,7 @@ function cmake.clean(callback)
     return log.error(result.message)
   end
 
-  local args = { "--build", config.build_directory.filename, "--target", "clean" }
+  local args = { "--build", '"' .. config.build_directory.filename .. '"', "--target", "clean" }
 
   local env = environment.get_build_environment(config, config.always_use_terminal)
 
@@ -284,15 +320,33 @@ function cmake.clean(callback)
     if type(callback) == "function" then
       return callback()
     else
-      utils.run(full_cmd, config.env_script, {}, {}, config.cwd, config.executor, nil, const.cmake_notifications)
+      utils.run(
+        full_cmd,
+        config.env_script,
+        {},
+        {},
+        config.cwd,
+        config.executor,
+        nil,
+        const.cmake_notifications
+      )
       full_cmd = ""
     end
   else
-    return utils.run(const.cmake_command, config.env_script, env, args, config.cwd, config.executor, function()
-      if type(callback) == "function" then
-        callback()
-      end
-    end, const.cmake_notifications)
+    return utils.run(
+      const.cmake_command,
+      config.env_script,
+      env,
+      args,
+      config.cwd,
+      config.executor,
+      function()
+        if type(callback) == "function" then
+          callback()
+        end
+      end,
+      const.cmake_notifications
+    )
   end
 end
 
@@ -335,7 +389,7 @@ function cmake.build(opt, callback)
   if presets_file and config.build_preset then
     args = { "--build", "--preset", config.build_preset } -- preset don't need define build dir.
   else
-    args = { "--build", config.build_directory.filename }
+    args = { "--build", '"' .. config.build_directory.filename .. '"' }
   end
 
   vim.list_extend(args, config:build_options())
@@ -361,15 +415,33 @@ function cmake.build(opt, callback)
     if type(callback) == "function" then
       callback()
     else
-      utils.run(full_cmd, config.env_script, {}, {}, config.cwd, config.executor, nil, const.cmake_notifications)
+      utils.run(
+        full_cmd,
+        config.env_script,
+        {},
+        {},
+        config.cwd,
+        config.executor,
+        nil,
+        const.cmake_notifications
+      )
       full_cmd = ""
     end
   else
-    utils.run(const.cmake_command, config.env_script, env, args, config.cwd, config.executor, function()
-      if type(callback) == "function" then
-        callback()
-      end
-    end, const.cmake_notifications)
+    utils.run(
+      const.cmake_command,
+      config.env_script,
+      env,
+      args,
+      config.cwd,
+      config.executor,
+      function()
+        if type(callback) == "function" then
+          callback()
+        end
+      end,
+      const.cmake_notifications
+    )
   end
 end
 
@@ -427,7 +499,7 @@ function cmake.install(opt)
 
   local fargs = opt.fargs
 
-  local args = { "--install", config.build_directory.filename }
+  local args = { "--install", '"' .. config.build_directory.filename .. '"' }
   vim.list_extend(args, fargs)
   return utils.run(
     const.cmake_command,
@@ -479,13 +551,13 @@ function cmake.get_launch_path(target)
 
   if config.base_settings.working_dir and type(config.base_settings.working_dir) == "string" then
     launch_path =
-        cmake.substitute_path(config.base_settings.working_dir, cmake.get_target_vars(target))
+      cmake.substitute_path(config.base_settings.working_dir, cmake.get_target_vars(target))
   end
 
   if
-      config.target_settings[target]
-      and config.target_settings[target].working_dir
-      and type(config.target_settings[target].working_dir) == "string"
+    config.target_settings[target]
+    and config.target_settings[target].working_dir
+    and type(config.target_settings[target].working_dir) == "string"
   then
     launch_path = config.target_settings[target].working_dir
     launch_path = cmake.substitute_path(launch_path, cmake.get_target_vars(target))
@@ -511,17 +583,17 @@ function cmake.run(opt)
 
       if full_cmd ~= "" then
         full_cmd = 'cd "'
-            .. config.cwd
-            .. '" && '
-            .. full_cmd
-            .. " && "
-            .. terminal.prepare_cmd_for_execute(
-              target_path,
-              opt.args,
-              launch_path,
-              opt.wrap_call,
-              environment.get_run_environment(config, opt.target, true)
-            )
+          .. config.cwd
+          .. '" && '
+          .. full_cmd
+          .. " && "
+          .. terminal.prepare_cmd_for_execute(
+            target_path,
+            opt.args,
+            launch_path,
+            opt.wrap_call,
+            environment.get_run_environment(config, opt.target, true)
+          )
       else
         full_cmd = terminal.prepare_cmd_for_execute(
           target_path,
@@ -549,9 +621,9 @@ function cmake.run(opt)
         end)
       end
     elseif
-        result_code == Types.NOT_SELECT_LAUNCH_TARGET
-        or result_code == Types.NOT_A_LAUNCH_TARGET
-        or result_code == Types.NOT_EXECUTABLE
+      result_code == Types.NOT_SELECT_LAUNCH_TARGET
+      or result_code == Types.NOT_A_LAUNCH_TARGET
+      or result_code == Types.NOT_EXECUTABLE
     then
       -- Re Select a target that could launch
       return cmake.select_launch_target(function()
@@ -570,17 +642,17 @@ function cmake.run(opt)
           -- This jumps to the working directory, builds the target and then launches it inside the launch terminal
           -- Hence, "cd ".. cwd .. " && "..    The \" is for path handling, specifically in win32
           full_cmd = 'cd "'
-              .. config.cwd
-              .. '" && '
-              .. full_cmd
-              .. " && "
-              .. terminal.prepare_cmd_for_execute(
-                target_path,
-                cmake:get_launch_args(),
-                launch_path,
-                opt.wrap_call,
-                environment.get_run_environment(config, config.launch_target, true)
-              )
+            .. config.cwd
+            .. '" && '
+            .. full_cmd
+            .. " && "
+            .. terminal.prepare_cmd_for_execute(
+              target_path,
+              cmake:get_launch_args(),
+              launch_path,
+              opt.wrap_call,
+              environment.get_run_environment(config, config.launch_target, true)
+            )
         else
           full_cmd = terminal.prepare_cmd_for_execute(
             target_path,
@@ -747,15 +819,15 @@ if has_nvim_dap then
           end)
         end
       elseif
-          result_code == Types.NOT_SELECT_LAUNCH_TARGET
-          or result_code == Types.NOT_A_LAUNCH_TARGET
-          or result_code == Types.NOT_EXECUTABLE
+        result_code == Types.NOT_SELECT_LAUNCH_TARGET
+        or result_code == Types.NOT_A_LAUNCH_TARGET
+        or result_code == Types.NOT_EXECUTABLE
       then
         -- Re Select a target that could launch
         return cmake.select_launch_target(function()
-              cmake.debug(opt, callback)
-            end),
-            true
+          cmake.debug(opt, callback)
+        end),
+          true
       else -- if result_code == Types.SELECTED_LAUNCH_TARGET_NOT_BUILT then
         -- Build select launch target every time
         config.build_target = config.launch_target
@@ -910,9 +982,9 @@ function cmake.select_configure_preset(callback)
   local presets_file = presets.check(config.cwd)
   if presets_file then
     local configure_preset_names =
-        presets.parse("configurePresets", { include_hidden = false }, config.cwd)
+      presets.parse("configurePresets", { include_hidden = false }, config.cwd)
     local configure_presets =
-        presets.parse_name_mapped("configurePresets", { include_hidden = false }, config.cwd)
+      presets.parse_name_mapped("configurePresets", { include_hidden = false }, config.cwd)
     local format_preset_name = function(p_name)
       local p = configure_presets[p_name]
       return p.displayName or p.name
@@ -1118,8 +1190,8 @@ local function convert_to_table(str)
   end
 
   if pcall(function()
-        vim.inspect(fn())
-      end) then
+    vim.inspect(fn())
+  end) then
     str = "return " .. vim.inspect(fn())
     fn = loadstring(str)
     if not fn then
@@ -1233,8 +1305,8 @@ function cmake.get_launch_args()
     return {}
   end
   if
-      config.target_settings[cmake.get_launch_target()]
-      and config.target_settings[cmake.get_launch_target()].args
+    config.target_settings[cmake.get_launch_target()]
+    and config.target_settings[cmake.get_launch_target()].args
   then
     return config.target_settings[cmake.get_launch_target()].args
   end

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -200,20 +200,20 @@ function cmake.generate(opt, callback)
     end
   end
 
-  -- specify build type, if exists cmake-variants.json,
-  -- this will get build variant from it. Or this will
-  -- get build variant from "Debug, Release, RelWithDebInfo, MinSizeRel"
-  if not config.build_type then
-    return cmake.select_build_type(function()
-      cmake.generate(opt, callback)
-    end)
-  end
-
   -- if exists cmake-kits.json, kit is used to set
   -- environmental variables and args.
   local kits_config = kits.parse(const.cmake_kits_path, config.cwd)
   if kits_config and not config.kit then
     return cmake.select_kit(function()
+      cmake.generate(opt, callback)
+    end)
+  end
+
+  -- specify build type, if exists cmake-variants.json,
+  -- this will get build variant from it. Or this will
+  -- get build variant from "Debug, Release, RelWithDebInfo, MinSizeRel"
+  if not config.build_type then
+    return cmake.select_build_type(function()
       cmake.generate(opt, callback)
     end)
   end

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -241,7 +241,7 @@ function cmake.generate(opt, callback)
 
   local args = {
     "-B",
-    config.build_directory.filename ,
+    config.build_directory.filename,
     "-S",
     ".",
   }

--- a/lua/cmake-tools/kits.lua
+++ b/lua/cmake-tools/kits.lua
@@ -10,7 +10,7 @@ function kits.parse(global_kits_path, cwd)
     -- it will use local kits path first,
     -- otherwise, it will use global kits path
     local file = global_kits_path
-    for _, f in ipairs(files) do                              -- iterate over files in current directory
+    for _, f in ipairs(files) do -- iterate over files in current directory
       if f == "cmake-kits.json" or f == "CMakeKits.json" then -- if a kits config file is found
         file = vim.fn.resolve(cwd .. "/" .. f)
         break
@@ -22,8 +22,8 @@ function kits.parse(global_kits_path, cwd)
   -- start parsing
   local config = nil
 
-  local file = findcfg()           -- check for config file
-  if file then                     -- if one is found ...
+  local file = findcfg() -- check for config file
+  if file then -- if one is found ...
     if file:match(".*%.json") then -- .. and is a json file
       config = vim.fn.json_decode(vim.fn.readfile(file))
     end

--- a/lua/cmake-tools/kits.lua
+++ b/lua/cmake-tools/kits.lua
@@ -10,7 +10,7 @@ function kits.parse(global_kits_path, cwd)
     -- it will use local kits path first,
     -- otherwise, it will use global kits path
     local file = global_kits_path
-    for _, f in ipairs(files) do -- iterate over files in current directory
+    for _, f in ipairs(files) do                              -- iterate over files in current directory
       if f == "cmake-kits.json" or f == "CMakeKits.json" then -- if a kits config file is found
         file = vim.fn.resolve(cwd .. "/" .. f)
         break
@@ -22,8 +22,8 @@ function kits.parse(global_kits_path, cwd)
   -- start parsing
   local config = nil
 
-  local file = findcfg() -- check for config file
-  if file then -- if one is found ...
+  local file = findcfg()           -- check for config file
+  if file then                     -- if one is found ...
     if file:match(".*%.json") then -- .. and is a json file
       config = vim.fn.json_decode(vim.fn.readfile(file))
     end
@@ -64,9 +64,10 @@ function kits.build_env_and_args(kit_name, always_use_terminal, cwd, global_kits
   local kit = kits.get_by_name(kit_name, cwd, global_kits_path)
   local args = {}
   local env = {}
+  local env_script = " "
 
   if not kit then
-    return { env = env, args = args } -- silent error (empty arglist) if no config file found
+    return { env = env, env_script = env_script, args = args } -- silent error (empty arglist) if no config file found
   end
 
   -- local function to add an argument to `args`
@@ -82,6 +83,10 @@ function kits.build_env_and_args(kit_name, always_use_terminal, cwd, global_kits
     end
   end
 
+  if kit.environmentSetupScript then
+    env_script = kit.environmentSetupScript
+    -- vim.print(env_script)
+  end
   -- if exists `compilers` option, then set variable for cmake
   if kit.compilers then
     for lang, compiler in pairs(kit.compilers) do
@@ -123,7 +128,7 @@ function kits.build_env_and_args(kit_name, always_use_terminal, cwd, global_kits
       add_env({ k .. "=" .. v })
     end
   end
-  return { env = env, args = args }
+  return { env = env, env_script = env_script, args = args }
 end
 
 return kits

--- a/lua/cmake-tools/quickfix.lua
+++ b/lua/cmake-tools/quickfix.lua
@@ -95,8 +95,8 @@ function quickfix.has_active_job(opts)
   end
   log.error(
     "A CMake task is already running: "
-    .. quickfix.job.command
-    .. " Stop it before trying to run a new CMake task."
+      .. quickfix.job.command
+      .. " Stop it before trying to run a new CMake task."
   )
   return true
 end

--- a/lua/cmake-tools/quickfix.lua
+++ b/lua/cmake-tools/quickfix.lua
@@ -32,11 +32,13 @@ function quickfix.close(opts)
   vim.api.nvim_command("cclose")
 end
 
-function quickfix.run(cmd, env, args, cwd, opts, on_exit, on_output)
+function quickfix.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output)
   vim.fn.setqflist({}, " ", { title = cmd .. " " .. table.concat(args, " ") })
   if opts.show == "always" then
     quickfix.show(opts)
   end
+
+  -- NOTE: Unused env_script for quickfix.run() as plenary does not yet support running scripts
 
   local job_args = {}
 
@@ -93,8 +95,8 @@ function quickfix.has_active_job(opts)
   end
   log.error(
     "A CMake task is already running: "
-      .. quickfix.job.command
-      .. " Stop it before trying to run a new CMake task."
+    .. quickfix.job.command
+    .. " Stop it before trying to run a new CMake task."
   )
   return true
 end

--- a/lua/cmake-tools/session.lua
+++ b/lua/cmake-tools/session.lua
@@ -76,6 +76,7 @@ function session.save(config)
     launch_target = config.launch_target,
     kit = config.kit,
     configure_preset = config.configure_preset,
+    env_script = config.env_script,
     build_preset = config.build_preset,
     base_settings = config.base_settings,
     target_settings = config.target_settings,

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -81,7 +81,7 @@ end
 function utils.softlink(src, target, use_terminal, cwd, opts)
   if use_terminal and not utils.file_exists(target) then
     local cmd = "cmake -E create_symlink " .. src .. " " .. target
-    terminal.run(cmd, {}, {}, cwd, opts)
+    terminal.run(cmd, "", {}, {}, cwd, opts)
     return
   end
 
@@ -116,7 +116,7 @@ end
 local notify_update_line = function(out, err)
   local line = err and err or out
   if line ~= nil then
-    if line and line:match("^%[%s*(%d+)%s*%%%]") then -- only show lines containing build progress e.g [ 12%]
+    if line and line:match("^%[%s*(%d+)%s*%%%]") then     -- only show lines containing build progress e.g [ 12%]
       notification.notification.id = notification.notify( -- notify with percentage and message
         line,
         err and "warn" or notification.notification.level,
@@ -128,13 +128,14 @@ end
 
 ---Run a commond
 ---@param cmd string the executable to execute
+---@param env_script string environment setup script
 ---@param env table environment variables
 ---@param args table arguments to the executable
 ---@param cwd string the directory to run in
 ---@param executor_data executor_conf the executor
 ---@param on_success nil|function extra arguments, f.e on_success is a callback to be called when the process finishes
 ---@return nil
-function utils.run(cmd, env, args, cwd, executor_data, on_success, cmake_notifications)
+function utils.run(cmd, env_script, env, args, cwd, executor_data, on_success, cmake_notifications)
   -- save all
   vim.cmd("wall")
 
@@ -145,11 +146,11 @@ function utils.run(cmd, env, args, cwd, executor_data, on_success, cmake_notific
     notification.notification.level = "info"
 
     notification.notification.id =
-      notification.notify(cmd, notification.notification.level, { title = "CMakeTools" })
+        notification.notify(cmd, notification.notification.level, { title = "CMakeTools" })
     notification.update_spinner()
   end
 
-  utils.get_executor(executor_data.name).run(cmd, env, args, cwd, executor_data.opts, function(code)
+  utils.get_executor(executor_data.name).run(cmd, env_script, env, args, cwd, executor_data.opts, function(code)
     local msg = "Exited with code " .. code
     local level = cmake_notifications.level
     local icon = ""
@@ -175,7 +176,7 @@ end
 -- @return true if exists else false
 function utils.has_active_job(terminal_data, executor_data)
   return utils.get_executor(executor_data.name).has_active_job(executor_data.opts)
-    or utils.get_executor(terminal_data.name).has_active_job(terminal_data.opts)
+      or utils.get_executor(terminal_data.name).has_active_job(terminal_data.opts)
 end
 
 function utils.mkdir(dir)

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -116,7 +116,7 @@ end
 local notify_update_line = function(out, err)
   local line = err and err or out
   if line ~= nil then
-    if line and line:match("^%[%s*(%d+)%s*%%%]") then     -- only show lines containing build progress e.g [ 12%]
+    if line and line:match("^%[%s*(%d+)%s*%%%]") then -- only show lines containing build progress e.g [ 12%]
       notification.notification.id = notification.notify( -- notify with percentage and message
         line,
         err and "warn" or notification.notification.level,
@@ -146,28 +146,30 @@ function utils.run(cmd, env_script, env, args, cwd, executor_data, on_success, c
     notification.notification.level = "info"
 
     notification.notification.id =
-        notification.notify(cmd, notification.notification.level, { title = "CMakeTools" })
+      notification.notify(cmd, notification.notification.level, { title = "CMakeTools" })
     notification.update_spinner()
   end
 
-  utils.get_executor(executor_data.name).run(cmd, env_script, env, args, cwd, executor_data.opts, function(code)
-    local msg = "Exited with code " .. code
-    local level = cmake_notifications.level
-    local icon = ""
-    if code ~= 0 then
-      level = "error"
-      icon = ""
-    end
-    notification.notify(
-      msg,
-      level,
-      { icon = icon, replace = notification.notification.id, timeout = 3000 }
-    )
-    notification.notification = {} -- reset and stop update_spinner
-    if code == 0 and on_success then
-      on_success()
-    end
-  end, notify_update_line)
+  utils
+    .get_executor(executor_data.name)
+    .run(cmd, env_script, env, args, cwd, executor_data.opts, function(code)
+      local msg = "Exited with code " .. code
+      local level = cmake_notifications.level
+      local icon = ""
+      if code ~= 0 then
+        level = "error"
+        icon = ""
+      end
+      notification.notify(
+        msg,
+        level,
+        { icon = icon, replace = notification.notification.id, timeout = 3000 }
+      )
+      notification.notification = {} -- reset and stop update_spinner
+      if code == 0 and on_success then
+        on_success()
+      end
+    end, notify_update_line)
 end
 
 --- Check if exists active job.
@@ -176,7 +178,7 @@ end
 -- @return true if exists else false
 function utils.has_active_job(terminal_data, executor_data)
   return utils.get_executor(executor_data.name).has_active_job(executor_data.opts)
-      or utils.get_executor(terminal_data.name).has_active_job(terminal_data.opts)
+    or utils.get_executor(terminal_data.name).has_active_job(terminal_data.opts)
 end
 
 function utils.mkdir(dir)


### PR DESCRIPTION
Added "environmentSetupScript" option in terminal execution. 
Does not yet work in overseer or quickfix list, but option is provided (I'm not sure how to use overseer 😅)

```json
    {
        "name": "Windows Clang 16.0",
        "environmentSetupScript": "& \"C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat\"",
        "generator": "Ninja",
        "linker" : "C:/Program Files/LLVM/bin/lld-link.exe",
        "compilers": {
            "C": "C:/Program Files/LLVM/bin/clang.exe",
            "CXX": "C:/Program Files/LLVM/bin/clang.exe"
        }
    }
```

Ref: https://github.com/microsoft/vscode-cmake-tools/issues/809#issuecomment-662166588

---

#### EDIT: 

Additionally, minor semantic terminal mode fixes.