### PR TITLE
Fix the clangd update to remove the old arg and add the new one

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1305,17 +1305,13 @@ end
 function cmake.clangd_on_new_config(new_config)
   const.lsp_type = "clangd"
 
-  local found = false
   local arg = "--compile-commands-dir=" .. config.build_directory.filename
-  for _, v in ipairs(new_config.cmd) do
+  for i, v in ipairs(new_config.cmd) do
     if string.find(v, "%-%-compile%-commands%-dir=") ~= nil then
-      found = true
-      break
+      table.remove(new_config.cmd, i)
     end
   end
-  if found ~= true then
-    table.insert(new_config.cmd, arg)
-  end
+  table.insert(new_config.cmd, arg)
 end
 
 function cmake.ccls_on_new_config(new_config)


### PR DESCRIPTION
When i used this plugin and changed the build type, it only took affect after restarting vim (restarting clangd did not help)

After looking at the code i found it only adds the compile commands path once, and after that it never updates it.

This pull request makes it so every time we update the build type/preset, it will remove any flag for a compile commands, and add the updated one, to ensure it is the only one passed to clangd.

This allows me to change from release to debug without restarting neovim, and seeing the changes happen immediately.