### PR TITLE
update configurePreset when changing buildPreset

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -968,8 +968,21 @@ function cmake.select_build_preset(callback)
         if config.build_preset ~= choice then
           config.build_preset = choice
         end
+        local associated_configure_preset =
+          presets.get_preset_by_name(choice, "buildPresets", config.cwd)["configurePreset"]
+        local configure_preset_updated = false
+
+        if
+          associated_configure_preset and config.configure_preset ~= associated_configure_preset
+        then
+          config.configure_preset = associated_configure_preset
+          configure_preset_updated = true
+        end
+
         if type(callback) == "function" then
           callback()
+        elseif configure_preset_updated then
+          cmake.generate({ bang = true, fargs = {} }, nil)
         end
       end)
     )


### PR DESCRIPTION
A buildPreset can have a configurePreset associated with it. When changing the buildPreset, the configurePreset should be updated accordingly.

After updating the configurePreset, we have to re-generate using the bang option as the new configurePreset might differ in the set cacheVariables and we have to get rid of the cached variables of the previous preset.

Question: should `select_configure_preset` use the bang option as per default as well? Keeping the `cacheVariables` values from the previous preset cached was unexpected to me 😅 

Fixes https://github.com/Civitasv/cmake-tools.nvim/issues/148#issue-1881394109