### PR TITLE
Minor fixes - reading cmakepresets includes, add option to remove build preset and correct sourcedir on preset

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -952,11 +952,10 @@ function cmake.select_build_preset(callback)
   local presets_file = presets.check(config.cwd)
   if presets_file then
     local build_preset_names = presets.parse("buildPresets", { include_hidden = false }, config.cwd)
-
     local build_presets =
       presets.parse_name_mapped("buildPresets", { include_hidden = false }, config.cwd)
-    build_preset_names = vim.list_extend( build_preset_names, {"None"})
-    build_presets = vim.tbl_extend("keep", build_presets, {None={displayName="None"}})
+    build_preset_names = vim.list_extend(build_preset_names, { "None" })
+    build_presets = vim.tbl_extend("keep", build_presets, { None = { displayName = "None" } })
     local format_preset_name = function(p_name)
       local p = build_presets[p_name]
       return p.displayName or p.name
@@ -967,16 +966,16 @@ function cmake.select_build_preset(callback)
       vim.schedule_wrap(function(choice)
         if not choice then
           return
-	end
-	if choice=="None" then
-          	config.build_preset = nil
-		return
+        end
+        if choice == "None" then
+          config.build_preset = nil
+          return
         end
         if config.build_preset ~= choice then
           config.build_preset = choice
         end
-	local associated_configure_preset =
-	   presets.get_preset_by_name(choice, "buildPresets", config.cwd)["configurePreset"]
+        local associated_configure_preset =
+          presets.get_preset_by_name(choice, "buildPresets", config.cwd)["configurePreset"]
         local configure_preset_updated = false
 
         if

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -952,8 +952,11 @@ function cmake.select_build_preset(callback)
   local presets_file = presets.check(config.cwd)
   if presets_file then
     local build_preset_names = presets.parse("buildPresets", { include_hidden = false }, config.cwd)
+
     local build_presets =
       presets.parse_name_mapped("buildPresets", { include_hidden = false }, config.cwd)
+    build_preset_names = vim.list_extend( build_preset_names, {"None"})
+    build_presets = vim.tbl_extend("keep", build_presets, {None={displayName="None"}})
     local format_preset_name = function(p_name)
       local p = build_presets[p_name]
       return p.displayName or p.name
@@ -964,12 +967,16 @@ function cmake.select_build_preset(callback)
       vim.schedule_wrap(function(choice)
         if not choice then
           return
+	end
+	if choice=="None" then
+          	config.build_preset = nil
+		return
         end
         if config.build_preset ~= choice then
           config.build_preset = choice
         end
-        local associated_configure_preset =
-          presets.get_preset_by_name(choice, "buildPresets", config.cwd)["configurePreset"]
+	local associated_configure_preset =
+	   presets.get_preset_by_name(choice, "buildPresets", config.cwd)["configurePreset"]
         local configure_preset_updated = false
 
         if

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -79,9 +79,9 @@ local function decode(file)
     local f_read_data = nil
     local f_path = Path.new(f)
     if f_path:is_absolute() then
-	f_read_data = f_path:read()
+      f_read_data = f_path:read()
     else
-	f_read_data = (Path.new(parentDir)/ f):read()
+      f_read_data = (Path.new(parentDir) / f):read()
     end
 
     local fdata = vim.fn.json_decode(f_read_data)

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -76,7 +76,7 @@ local function decode(file)
   end
 
   for _, f in ipairs(includes) do
-    local fdata = vim.fn.json_decode(vim.fn.readfile(f))
+    local fdata = vim.fn.json_decode((Path.new(file):parent() / f):read())
     local thisFilePresetKeys = vim.tbl_filter(function(key)
       if string.find(key, "Presets") then
         return true

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -57,8 +57,8 @@ local function decode(file)
   end
   local includes = data["include"] or {}
   local isUserPreset = string.find(file:lower(), "user")
+  local parentDir = vim.fs.dirname(file)
   if #includes == 0 and isUserPreset then
-    local parentDir = vim.fs.dirname(file)
     local preset = "CMakePresets.json"
     local presetKebapCase = "cmake-presets.json"
     local presetPath = parentDir .. "/" .. preset
@@ -76,7 +76,15 @@ local function decode(file)
   end
 
   for _, f in ipairs(includes) do
-    local fdata = vim.fn.json_decode((Path.new(file):parent() / f):read())
+    local f_read_data = nil
+    local f_path = Path.new(f)
+    if f_path:is_absolute() then
+	f_read_data = f_path:read()
+    else
+	f_read_data = (Path.new(parentDir)/ f):read()
+    end
+
+    local fdata = vim.fn.json_decode(f_read_data)
     local thisFilePresetKeys = vim.tbl_filter(function(key)
       if string.find(key, "Presets") then
         return true

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -218,11 +218,7 @@ function presets.get_build_dir(preset, cwd)
   local source_path = Path:new(cwd)
   local source_relative = vim.fn.fnamemodify(cwd, ":t")
 
-  local cwd = cwd
-  if not cwd then
-    cwd = "."
-  end
-  build_dir = build_dir:gsub("${sourceDir}", cwd)
+  build_dir = build_dir:gsub("${sourceDir}", ".") -- sourceDir is relative to the CMakePresests.json file, and should be relative
   build_dir = build_dir:gsub("${sourceParentDir}", source_path:parent().filename)
   build_dir = build_dir:gsub("${sourceDirName}", source_relative)
   build_dir = build_dir:gsub("${presetName}", preset.name)


### PR DESCRIPTION
Hey, this merge request contains 3 little fixes/features:
1. If cmakepreset has an include for a file, we should read the file as a relative path to the presets file
2. add option of `buildPreset=None` in case  the user wants to not use a build preset anymore
3. Changed the sourceDir expantion on presets.json to be "." instead of the supplied cwd. The reason is the sourceDir is relative to the presets file. And when we invoke cmake we already use the new cwd, so the source dir is the current dir. (Without this change, using `CMakeRun` with a preset file with another cwd does not work.