### PR TITLE
Temp: Disable envScript in Overseer

### DIFF
--- a/lua/cmake-tools/executors/overseer.lua
+++ b/lua/cmake-tools/executors/overseer.lua
@@ -16,7 +16,8 @@ end
 
 function overseer_executor.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output)
   opts = vim.tbl_extend("keep", {
-    cmd = env_script .. " && " .. cmd,
+    -- cmd = env_script .. " && " .. cmd, -- Temporarily disabling envScript for Overseer: Refer #158 and #159 for more details
+    cmd = cmd,
     args = args,
     env = env,
     cwd = cwd,


### PR DESCRIPTION
Temporarily fixing #158 and #159 by disabling envScript for overseer in preparation for #145 and #151