### PR TITLE
Command CMakeStop now stops terminal processes as well

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -489,6 +489,7 @@ function cmake.stop()
   end
 
   utils.stop(config.executor)
+  utils.stop(config.terminal)
 end
 
 --- CMake install targets


### PR DESCRIPTION
I noticed there isn't a simple way to cancel a running target, since the terminal is unmodified. This can be annoying when doing gui development as sometimes the exec loop is just running and you have no way to stop it.

I extended the `cmake.stop` function to stop any running terminals as well as executors.

Now when you run `:CmakeStop` it stops the running terminal too.