### PR TITLE
Fix: Re-Generate CMake only after selection of cwd has finished

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1440,9 +1440,9 @@ function cmake.select_cwd(cwd_path)
         --if new_path:is_dir() then
         config.cwd = vim.fn.resolve(input)
         --	end
+        cmake.generate({ bang = false, fargs = {} }, nil)
       end)
     )
-    cmake.generate({ bang = false, fargs = {} }, nil)
   elseif cwd_path.args then
     config.cwd = vim.fn.resolve(cwd_path.args)
     cmake.generate({ bang = false, fargs = {} }, nil)


### PR DESCRIPTION
Since 56b4c34 cwd selection is broken. Since this cwd selection is async, we should only regenerate when selection is finished. Otherwise the selection window will lose focus and the old cwd will get regenerated.