### PR TITLE
don't try to read kits when there is no file present

### DIFF
--- a/lua/cmake-tools/kits.lua
+++ b/lua/cmake-tools/kits.lua
@@ -23,7 +23,9 @@ function kits.parse(global_kits_path, cwd)
   local config = nil
 
   local file = findcfg() -- check for config file
-
+  if file == nil then
+    return config
+  end
   file = file:gsub("~", vim.fn.expand("~"))
   if file then -- if one is found ...
     if file:match(".*%.json") then -- .. and is a json file


### PR DESCRIPTION
I've never used kits and therefore don't have any of those files that are checked lying around.
At some point the plugin started to error out on CMakeGenerate/CMakeBuild commands.

I had a look and implemented a simple check whether a config file has been found.
