### PR TITLE
Option to review command executed by :CMakeRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ require("cmake-tools").setup {
       start_insert_in_other_tasks = false, -- If you want to enter terminal with :startinsert upon launching all other cmake tasks in the terminal. Generally set as false
       focus_on_main_terminal = false, -- Focus on cmake terminal when cmake task is launched. Only used if executor is terminal.
       focus_on_launch_terminal = false, -- Focus on cmake launch terminal when executable target in launched.
+      do_not_add_newline = false, -- Do not hit enter on the command inserted when using :CMakeRun, allowing a chance to review or modify the command before hitting enter.
     },
   },
   cmake_notifications = {

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -55,6 +55,7 @@ local const = {
       start_insert_in_other_tasks = false, -- If you want to enter terminal with :startinsert upon launching all other cmake tasks in the terminal. Generally set as false
       focus_on_main_terminal = false, -- Focus on cmake terminal when cmake task is launched. Only used if executor is terminal.
       focus_on_launch_terminal = false, -- Focus on cmake launch terminal when executable target in launched.
+      do_not_add_newline = false, -- Do not hit enter on the command inserted when using :CMakeRun, allowing a chance to review or modify the command before hitting enter.
     },
   },
   cmake_notifications = {

--- a/lua/cmake-tools/executors/terminal.lua
+++ b/lua/cmake-tools/executors/terminal.lua
@@ -143,15 +143,20 @@ function terminal.get_buffer_number_from_name(buffer_name)
 end
 
 function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
-  if osys.iswin32 then
-    cmd = cmd .. " \r"
-  elseif osys.ismac then
-    cmd = cmd .. " \n"
-  elseif osys.islinux then
-    cmd = cmd .. " \n"
-  elseif osys.iswsl then
-    --NOTE: Techinically, wsl-2 and linux are detected as linux. We might see a diferrence in wsl-1 vs wsl-2
-    cmd = cmd .. " \n"
+  if (not opts) or (not opts.do_not_add_newline) then
+    if osys.iswin32 then
+      cmd = cmd .. " \r"
+    elseif osys.ismac then
+      cmd = cmd .. " \n"
+    elseif osys.islinux then
+      cmd = cmd .. " \n"
+    elseif osys.iswsl then
+      --NOTE: Techinically, wsl-2 and linux are detected as linux. We might see a diferrence in wsl-1 vs wsl-2
+      cmd = cmd .. " \n"
+    end
+  else
+    -- Append a space but NOT the newline, so that the user has a chance to review the command before executing it
+    cmd = cmd .. " "
   end
 
   if opts and opts.win_id ~= -1 then
@@ -528,6 +533,7 @@ function terminal.execute(executable, full_cmd, opts)
     split_size = opts.split_size,
     start_insert = opts.start_insert_in_launch_task,
     focus_on_launch_terminal = opts.focus_on_launch_terminal,
+    do_not_add_newline = opts.do_not_add_newline,
   })
 end
 

--- a/lua/cmake-tools/executors/terminal.lua
+++ b/lua/cmake-tools/executors/terminal.lua
@@ -143,7 +143,7 @@ function terminal.get_buffer_number_from_name(buffer_name)
 end
 
 function terminal.send_data_to_terminal(buffer_idx, cmd, opts)
-  if (not opts) or (not opts.do_not_add_newline) then
+  if not opts or not opts.do_not_add_newline then
     if osys.iswin32 then
       cmd = cmd .. " \r"
     elseif osys.ismac then


### PR DESCRIPTION
Added an option that disables sending the new line character when using `:CMakeRun` to give the user a chance to review and/or modify the command before it is executed.