### PR TITLE
Fix: build dir for preset with inherited presets without configurePresets

### DIFF
--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -185,19 +185,21 @@ end
 function presets.get_build_dir(preset, cwd)
   -- check if this preset is extended
   local function helper(p_preset)
-    local build_dir = p_preset.name
-
     if not p_preset then
-      return build_dir
+      return ""
     end
+
+    local build_dir = p_preset.name
 
     if p_preset.inherits then
       local inherits = p_preset.inherits
       local set_dir_by_parent = function(parent)
         local ppreset = presets.get_preset_by_name(parent, "configurePresets", cwd)
-        local ppreset_build_dir = helper(ppreset)
-        if ppreset_build_dir ~= "" then
-          build_dir = ppreset_build_dir
+        if ppreset ~= nil then
+          local ppreset_build_dir = helper(ppreset)
+          if ppreset_build_dir ~= "" then
+            build_dir = ppreset_build_dir
+          end
         end
       end
 

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -189,43 +189,39 @@ function presets.get_build_dir(preset, cwd)
       return ""
     end
 
-    local build_dir = p_preset.name
+    if p_preset.binaryDir then
+      return p_preset.binaryDir
+    end
 
-    if p_preset.inherits then
-      local inherits = p_preset.inherits
+    local build_dir = p_preset.name
+    local inherits = p_preset.inherits
+    if inherits then
       local set_dir_by_parent = function(parent)
         local ppreset = presets.get_preset_by_name(parent, "configurePresets", cwd)
         if ppreset ~= nil then
           local ppreset_build_dir = helper(ppreset)
           if ppreset_build_dir ~= "" then
-            build_dir = ppreset_build_dir
+            return ppreset_build_dir
           end
         end
+        return nil
       end
-
       -- According to `https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html`,
       -- `inherits` field may be a list of strings or a single string.
       -- Check type then act.
       if type(inherits) == "table" then
-        -- iterate inherits from end, cause
-        -- If multiple inherits presets provide conflicting
-        -- values for the same field, the earlier preset in
-        -- the inherits array will be preferred.
-        for i = #inherits, 1, -1 do
-          local parent = inherits[i]
-
+        for _, parent in ipairs(inherits) do
           -- retrieve its parent preset
-          set_dir_by_parent(parent)
+          local dir = set_dir_by_parent(parent)
+          if dir then
+            build_dir = dir
+            break
+          end
         end
       elseif type(inherits) == "string" then
-        set_dir_by_parent(inherits)
+        build_dir = set_dir_by_parent(inherits) or build_dir
       end
     end
-
-    if p_preset.binaryDir then
-      build_dir = p_preset.binaryDir
-    end
-
     return build_dir
   end
 


### PR DESCRIPTION
A (build) preset might inherit from a preset without a configurePresets field set.
This causes p_preset to be nil when entering `helper`. The check for `not p_preset` does
not catch the unconditional access to `p_preset.name` resulting in an access to a nil variable

returning an empty string for a nil preset with the addtional nil check for the `ppreset` should
prevent the nil access.

The second commit is optional, but restructures the helper function a bit
