### PR TITLE
Fix cmake.get_launch_targets

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1139,6 +1139,8 @@ function cmake.get_cmake_launch_targets(callback)
   if type(callback) == "function" then
     callback(config:launch_targets())
   end
+
+  return config:launch_targets().data
 end
 
 function cmake.select_launch_target(callback, regenerate)


### PR DESCRIPTION
Hello and thanks for a great plugin!

My cmake projet has more than 400 targets and using `vim.ui.select` was a bit complicated, so I decided to use telescope to select build/launch target. To do this I needed to get a list of all available targets and found the function `get_cmake_launch_targets`. However, in the master branch it always returns 'nil'. This PR fixes that

Here is the telescope-based selector of targets (not part of the PR). It selects both build and launch targets at the same time
```
local actions = require "telescope.actions"
local action_state = require "telescope.actions.state"
local pickers = require "telescope.pickers"
local finders = require "telescope.finders"
local conf = require("telescope.config").values

local cmake = require("cmake-tools")

function select_cmake_target(opts)
    opts = opts or {}
    opts.cwd = opts.cwd or vim.fn.getcwd()

    local data = cmake.get_cmake_launch_targets()

    pickers.new(opts, {
        prompt_title = 'Select Target',
        finder = finders.new_table {
            results = data.display_targets,
        },
        sorter = conf.generic_sorter(opts),
        attach_mappings = function(prompt_bufnr, map)
            actions.select_default:replace(function()
                actions.close(prompt_bufnr)
                local selection = action_state.get_selected_entry()
                local target = data.targets[selection.index]
                cmake.get_config().build_target = target 
                cmake.get_config().launch_target = target 
            end)
            return true
        end,
    }):find()
end
```