### PR TITLE
Add support for *BSD

### DIFF
--- a/lua/cmake-tools/osys.lua
+++ b/lua/cmake-tools/osys.lua
@@ -3,6 +3,7 @@ local os = {
   ismac = vim.fn.has("mac") == 1,
   iswsl = vim.fn.has("wsl") == 1,
   islinux = vim.fn.has("linux") == 1,
+  isbsd = vim.fn.has("bsd") == 1,
 }
 
 return os

--- a/lua/cmake-tools/session.lua
+++ b/lua/cmake-tools/session.lua
@@ -16,6 +16,8 @@ local function get_cache_path()
     return session.dir.mac
   elseif osys.iswsl then
     return session.dir.unix
+  elseif osys.isbsd then
+    return session.dir.unix
   elseif osys.iswin32 then
     return session.dir.win
   end


### PR DESCRIPTION
Adds support for *BSD systems by using the unix session directory structure.
Without this the plugin will crash on the FreeBSD install I'm using.

I wonder if it would make sense to have a generic `isunix` bool and use that in this check's place to handle more platforms that should be using the same directory structure.
Haven't tested if this has the same behaviour on Linux but at least on my FreeBSD machine `vim.fn.has("unix")` will return 1 as well, so that could be used as a catch all.