### PR TITLE
Add option to not pass the '--presets' option to the cmake command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ local osys = require("cmake-tools.osys")
 require("cmake-tools").setup {
   cmake_command = "cmake", -- this is used to specify cmake command path
   ctest_command = "ctest", -- this is used to specify ctest command path
+  cmake_use_preset = true,
   cmake_regenerate_on_save = true, -- auto generate when save CMakeLists.txt
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- this will be passed when invoke `CMakeGenerate`
   cmake_build_options = {}, -- this will be passed when invoke `CMakeBuild`

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -20,6 +20,7 @@ return {
   },
   build_dir = nil,
   working_dir = "${dir.binary}"
+  use_preset = true,
   generate_options = {},
   build_options = {},
 }
@@ -109,6 +110,19 @@ Specify the working directory in which run and debug commands are executed. Supp
 |--------------         | --------------     |  --------------         |
 | `CMakeSettings`       | :white_check_mark: | Defines the working directory for all targets unless overwritten. |
 | `CMakeTargetSettings` | :white_check_mark: | Sets the working directory just for this target. No default value - Has to be added manually. |
+
+### `use_preset`
+
+Specify if the `--presets` argument should be used on `cmake` commands. This is useful when you want to control all of the `cmake` options with the `generate_options` and the `build_options`.
+
+```lua
+  use_preset = true
+```
+
+| Command               | Supported          | Details                 |
+|--------------         | --------------     |  --------------         |
+| `CMakeSettings`       | :white_check_mark: | Flag controlling if the `--presets` argument should be passed to the `cmake` commands |
+| `CMakeTargetSettings` | :x: | |
 
 ### `build_directory`
 

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -20,6 +20,7 @@ local Config = {
     env = {},
     build_dir = "",
     working_dir = "${dir.binary}",
+    use_preset = true,
     generate_options = {},
     build_options = {},
   }, -- general config
@@ -39,6 +40,7 @@ function Config:new(const)
 
   self.base_settings.generate_options = const.cmake_generate_options
   self.base_settings.build_options = const.cmake_build_options
+  self.base_settings.use_preset = const.cmake_use_preset
 
   self.executor = const.cmake_executor
   self.runner = const.cmake_runner

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -2,6 +2,7 @@ local osys = require("cmake-tools.osys")
 local const = {
   cmake_command = "cmake", -- this is used to specify cmake command path
   ctest_command = "ctest", -- this is used to specify ctest command path
+  cmake_use_preset = true, -- when `false`, this is used to define if the `--preset` option should be use on cmake commands
   cmake_regenerate_on_save = true, -- auto generate when save CMakeLists.txt
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- this will be passed when invoke `CMakeGenerate`
   cmake_build_options = {}, -- this will be passed when invoke `CMakeBuild`

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -83,7 +83,7 @@ function cmake.generate(opt, callback)
   -- if exists presets, preset include all info that cmake
   -- needed to execute, so we don't use cmake-kits.json and
   -- cmake-variants.[json|yaml] event they exist.
-  local presets_file = presets.check(config.cwd)
+  local presets_file = config.base_settings.use_preset and presets.check(config.cwd)
   if presets_file and not config.configure_preset then
     -- this will also set value for build type from preset.
     -- default to be "Debug"
@@ -242,7 +242,7 @@ function cmake.build(opt, callback)
   end
 
   local args
-  local presets_file = presets.check(config.cwd)
+  local presets_file = config.base_settings.use_preset and presets.check(config.cwd)
 
   if presets_file and config.build_preset then
     args = { "--build", "--preset", config.build_preset } -- preset don't need define build dir.
@@ -1238,7 +1238,7 @@ function cmake.create_regenerate_on_save_autocmd()
     table.insert(pattern, ss)
   end
 
-  local presets_file = presets.check(config.cwd)
+  local presets_file = config.base_settings.use_preset and presets.check(config.cwd)
   if presets_file then
     for _, item in ipairs({
       "CMakePresets.json",


### PR DESCRIPTION
## Changes Description

On CMake projects that use Conan as their package manager, there are two presets that are created with the same name. This always causes any `cmake` command issued by CMakeTools to fail. On those scenarios, the project usually specify the CMake options (including the preset location) as an argument to the `cmake` command.

This commit adds the option to not pass the `--preset` argument to the `cmake` command.