### PR TITLE
fix: command not ending when cmd doesnt exit successfully

### DIFF
--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -597,7 +597,7 @@ function _terminal.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output
   end
 
   -- Send final cmd to terminal
-  _terminal.send_data_to_terminal(buffer_idx, full_cmd .. " && " .. get_command_handling_on_exit(), {
+  _terminal.send_data_to_terminal(buffer_idx, full_cmd .. " ; " .. get_command_handling_on_exit(), {
     win_id = final_win_id,
     prefix = opts.prefix_name,
     split_direction = opts.split_direction,


### PR DESCRIPTION
this part is quite important expecially for tests because we want to get the exit code and delete lock even if command exits with an error code for example: when tests are failing and tests are made to fail