### PR TITLE
fix: transform path in utils.softlink()

### DIFF
--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -86,7 +86,12 @@ end
 function utils.softlink(src, target)
   if utils.file_exists(src) and not utils.file_exists(target) then
     -- if we don't always use terminal
-    local cmd = "silent exec " .. '"!cmake -E create_symlink ' .. src .. " " .. target .. '"'
+    local cmd = "exec "
+      .. "'!cmake -E create_symlink "
+      .. utils.transform_path(src)
+      .. " "
+      .. utils.transform_path(target)
+      .. "'"
     vim.cmd(cmd)
   end
 end


### PR DESCRIPTION
i had to swap `"` to `'` because we wrap paths in `"`, this fixes symlink not being created if the path contains the space character

possibly wil fix [issue213](https://github.com/Civitasv/cmake-tools.nvim/issues/213)