### PR TITLE
feat: change default build path for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ require("cmake-tools").setup {
   --       ${kit}
   --       ${kitGenerator}
   --       ${variant:xx}
-  cmake_build_directory = "out/${variant:buildType}", -- this is used to specify generate directory for cmake, allows macro expansion, relative to vim.loop.cwd()
+  cmake_build_directory = "out/${variant:buildType}", -- this is used to specify generate directory for cmake, allows macro expansion, relative to vim.loop.cwd(). ON WINDOWS => "out\\${variant:buildType}"
   cmake_soft_link_compile_commands = true, -- this will automatically make a soft link from compile commands file to project root dir
   cmake_compile_commands_from_lsp = false, -- this will automatically set compile commands file location using lsp, to use it, please set `cmake_soft_link_compile_commands` to false
   cmake_kits_path = nil, -- this is used to specify global cmake kits path, see CMakeKits for detailed usage

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The goal of this plugin is to offer a comprehensive, convenient, and powerful wo
 ## :balloon: Configuration
 
 ```lua
+local osys = require("cmake-tools.osys")
 require("cmake-tools").setup {
   cmake_command = "cmake", -- this is used to specify cmake command path
   ctest_command = "ctest", -- this is used to specify ctest command path

--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ require("cmake-tools").setup {
   --       ${kit}
   --       ${kitGenerator}
   --       ${variant:xx}
-  cmake_build_directory = "out/${variant:buildType}", -- this is used to specify generate directory for cmake, allows macro expansion, relative to vim.loop.cwd(). ON WINDOWS => "out\\${variant:buildType}"
+  cmake_build_directory = function()
+    if osys.iswin32 then
+      return "out\\${variant:buildType}"
+    end
+    return "out/${variant:buildType}"
+  end, -- this is used to specify generate directory for cmake, allows macro expansion, can be a string or a function returning the string, relative to vim.loop.cwd().
   cmake_soft_link_compile_commands = true, -- this will automatically make a soft link from compile commands file to project root dir
   cmake_compile_commands_from_lsp = false, -- this will automatically set compile commands file location using lsp, to use it, please set `cmake_soft_link_compile_commands` to false
   cmake_kits_path = nil, -- this is used to specify global cmake kits path, see CMakeKits for detailed usage

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ require("cmake-tools").setup {
       return "out\\${variant:buildType}"
     end
     return "out/${variant:buildType}"
-  end, -- this is used to specify generate directory for cmake, allows macro expansion, can be a string or a function returning the string, relative to vim.loop.cwd().
+  end, -- this is used to specify generate directory for cmake, allows macro expansion, can be a string or a function returning the string, relative to cwd.
   cmake_soft_link_compile_commands = true, -- this will automatically make a soft link from compile commands file to project root dir
   cmake_compile_commands_from_lsp = false, -- this will automatically set compile commands file location using lsp, to use it, please set `cmake_soft_link_compile_commands` to false
   cmake_kits_path = nil, -- this is used to specify global cmake kits path, see CMakeKits for detailed usage

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -87,10 +87,7 @@ function Config:update_build_dir(build_dir, no_expand_build_dir)
     self.reply_directory = Path:new(self.cwd, build_dir, ".cmake", "api", "v1", "reply")
   end
 
-  print(build_dir)
-  print(no_expand_build_dir)
   self.base_settings.build_dir = Path:new(no_expand_build_dir):absolute()
-  print(build_dir)
 end
 
 ---Prepare build directory. Which allows macro expansion.

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -58,7 +58,16 @@ function Config:no_expand_build_directory_path()
   return self.base_settings.build_dir
 end
 
+---comment
+---@param build_dir string|function string or a function returning string containing path to the build dir
+---@param no_expand_build_dir any
 function Config:update_build_dir(build_dir, no_expand_build_dir)
+  if type(build_dir) == "function" then
+    build_dir = build_dir()
+  end
+  if type(build_dir) ~= "string" then
+    error("build_dir needs to be a string or function returning string path to the build_directory")
+  end
   local build_path = Path:new(build_dir)
   if build_path:is_absolute() then
     self.build_directory = Path:new(build_dir)

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -72,7 +72,9 @@ function Config:update_build_dir(build_dir, no_expand_build_dir)
     no_expand_build_dir = no_expand_build_dir()
   end
   if type(no_expand_build_dir) ~= "string" then
-    error("no_expand_build_dir needs to be a string or function returning string path to the build_directory")
+    error(
+      "no_expand_build_dir needs to be a string or function returning string path to the build_directory"
+    )
   end
   local build_path = Path:new(build_dir)
   if build_path:is_absolute() then

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -60,13 +60,19 @@ end
 
 ---comment
 ---@param build_dir string|function string or a function returning string containing path to the build dir
----@param no_expand_build_dir any
+---@param no_expand_build_dir string|function
 function Config:update_build_dir(build_dir, no_expand_build_dir)
   if type(build_dir) == "function" then
     build_dir = build_dir()
   end
   if type(build_dir) ~= "string" then
     error("build_dir needs to be a string or function returning string path to the build_directory")
+  end
+  if type(no_expand_build_dir) == "function" then
+    no_expand_build_dir = no_expand_build_dir()
+  end
+  if type(no_expand_build_dir) ~= "string" then
+    error("no_expand_build_dir needs to be a string or function returning string path to the build_directory")
   end
   local build_path = Path:new(build_dir)
   if build_path:is_absolute() then
@@ -79,7 +85,10 @@ function Config:update_build_dir(build_dir, no_expand_build_dir)
     self.reply_directory = Path:new(self.cwd, build_dir, ".cmake", "api", "v1", "reply")
   end
 
+  print(build_dir)
+  print(no_expand_build_dir)
   self.base_settings.build_dir = Path:new(no_expand_build_dir):absolute()
+  print(build_dir)
 end
 
 ---Prepare build directory. Which allows macro expansion.

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -1,10 +1,16 @@
+local osys = require("cmake-tools.osys")
 local const = {
   cmake_command = "cmake", -- this is used to specify cmake command path
   ctest_command = "ctest", -- this is used to specify ctest command path
   cmake_regenerate_on_save = true, -- auto generate when save CMakeLists.txt
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- this will be passed when invoke `CMakeGenerate`
   cmake_build_options = {}, -- this will be passed when invoke `CMakeBuild`
-  cmake_build_directory = "out/${variant:buildType}", -- this is used to specify generate directory for cmake
+  cmake_build_directory = function()
+    if osys.iswin32 then
+      return "out\\${variant:buildType}"
+    end
+    return "out/${variant:buildType}"
+  end, -- this is used to specify generate directory for cmake
   cmake_soft_link_compile_commands = true, -- this will automatically make a soft link from compile commands file to project root dir
   cmake_compile_commands_from_lsp = false, -- this will automatically set compile commands file location using lsp, to use it, please set `cmake_soft_link_compile_commands` to false
   cmake_kits_path = nil, -- this is used to specify global cmake kits path, see CMakeKits for detailed usage
@@ -114,8 +120,5 @@ local const = {
   },
   cmake_virtual_text_support = true, -- Show the target related to current file using virtual text (at right corner)
 }
-local osys = require("cmake-tools.osys")
-if osys.iswin32 then
-  const.cmake_build_directory = "out\\${variant:buildType}"
-end
+
 return const

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -114,5 +114,8 @@ local const = {
   },
   cmake_virtual_text_support = true, -- Show the target related to current file using virtual text (at right corner)
 }
-
+local osys = require("cmake-tools.osys")
+if osys.iswin32 then
+  const.cmake_build_directory = "out\\${variant:buildType}"
+end
 return const


### PR DESCRIPTION
i added a very basic override when config is run on windows, didn't really know how to adnotate it properly in readme.
this should fix: [issue228](https://github.com/Civitasv/cmake-tools.nvim/issues/228),
if there will be a lot of mixed slashes errors for windows users we could add an slash check and replace in `utils.transform_path`