### PR TITLE
fix(terminal): failure to remove .lock file

### DIFF
--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -542,7 +542,7 @@ end
 local get_command_handling_on_exit = function()
   return "echo $? > "
     .. get_last_exit_code_file_path() -- write exitcode to file
-    .. " && rm "
+    .. " && \\rm -f "
     .. get_lock_file_path() -- remove lock file
 end
 


### PR DESCRIPTION
When the runner/executor is set to `terminal` the removal of the `.lock` file fails if the user has setup a shell alias for the `rm(1)` command that requires confirmation (e.g.: `alias rm='rm -iv'`).

In such case, the runner/executor does not finish and waits indefinitely for user confirmation: 
`remove ~/.local/share/nvim/cmake-tools-tmp/.lock?`

This PR bypasses any alias of `rm(1)` command and also uses the `-f` flag.