### PR TITLE
fix(quickfix): auto_close_when_success false is ignored

### DIFF
--- a/lua/cmake-tools/quickfix.lua
+++ b/lua/cmake-tools/quickfix.lua
@@ -69,13 +69,7 @@ function _quickfix.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output
         _quickfix.scroll_to_bottom()
       end
       if code == 0 and opts.auto_close_when_success then
-        vim.defer_fn(function()
-          _quickfix.close(opts)
-        end, 100)
-      end
-      if code == 0 and not opts.auto_close_when_success then
-        _quickfix.show(opts)
-        _quickfix.scroll_to_bottom()
+        _quickfix.close(opts)
       end
       if on_exit ~= nil then
         on_exit(code)

--- a/lua/cmake-tools/quickfix.lua
+++ b/lua/cmake-tools/quickfix.lua
@@ -73,6 +73,10 @@ function _quickfix.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output
           _quickfix.close(opts)
         end, 100)
       end
+      if code == 0 and not opts.auto_close_when_success then
+        _quickfix.show(opts)
+        _quickfix.scroll_to_bottom()
+      end
       if on_exit ~= nil then
         on_exit(code)
       end


### PR DESCRIPTION
When the runner/executor is set to `quickfix` and in the options `auto_close_when_success` is set to `false`, the `quickfix` window does not remain open.

This PR adds the missing check when success code = 0, auto close = false.

The issue is referenced also in the first bullet of https://github.com/Civitasv/cmake-tools.nvim/issues/201#issuecomment-2022290445