### PR TITLE
feat!(API): add callback(result) to lua API

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -81,10 +81,10 @@ end
 ---@return nil
 function cmake.generate(opt, callback)
   callback = callback or function() end
-  callback(Result:new(Types.SUCCESS, nil, nil))
   if check_active_job_and_notify(callback) then
     return
   end
+
   if get_cmake_configuration_or_notify(callback) == nil then
     return
   end
@@ -898,7 +898,7 @@ function cmake.get_cmake_launch_targets(callback)
     end)
   end
 
-  callback(Result:new(Types.SUCCESS, config:launch_targets(), nil))
+  callback(config:launch_targets())
 end
 
 function cmake.select_launch_target(regenerate, callback)

--- a/lua/cmake-tools/result.lua
+++ b/lua/cmake-tools/result.lua
@@ -1,18 +1,30 @@
+---@class cmake.Result
+---@field code number
+---@field data any
+---@field message string?
 local Result = {
   code = 0,
   data = nil,
   message = "",
 }
 
+---@return cmake.Result
 function Result:new(code, data, message)
   local obj = {}
-  setmetatable(obj, self)
-  self.__index = self
+  setmetatable(obj, { __index = self })
 
-  self.code = code
-  self.data = data
-  self.message = message
+  obj.code = code
+  obj.data = data
+  obj.message = message
   return obj
+end
+
+function Result:new_error(code, message)
+  return self:new(code, nil, message)
+end
+
+function Result:is_ok()
+  return self.code == 0
 end
 
 return Result

--- a/lua/cmake-tools/types.lua
+++ b/lua/cmake-tools/types.lua
@@ -1,26 +1,29 @@
-local function enum(tbl)
-  local length = #tbl
-  for i = 1, length do
-    local v = tbl[i]
-    tbl[v] = i
-  end
-
-  return tbl
-end
-
-local Types = enum({
-  "SUCCESS",
+local Types = {
   "NOT_CONFIGURED",
   "NOT_SELECT_LAUNCH_TARGET",
   "NOT_SELECT_BUILD_TARGET",
+  "NOT_SELECT_BUILD_TYPE",
+  "NOT_SELECT_KIT",
+  "NOT_SELECT_PRESET",
   "SELECTED_LAUNCH_TARGET_NOT_BUILT",
   "NOT_A_LAUNCH_TARGET",
   "NOT_EXECUTABLE",
   "CANNOT_FIND_CMAKE_CONFIGURATION_FILE",
   "CANNOT_FIND_CODEMODEL_FILE",
+  "CANNOT_FIND_KITS_FILE",
+  "CANNOT_FIND_PRESETS_FILE",
   "CANNOT_CREATE_CODEMODEL_QUERY_FILE",
   "CANNOT_DEBUG_LAUNCH_TARGET",
   "CANNOT_CREATE_DIRECTORY",
-})
+  "ANOTHER_JOB_RUNNING",
+  "CMAKE_RUN_FAILED",
+  "SETTINGS_ALREADY_OPENED",
+}
+
+Types[0] = "SUCCESS"
+
+for k, v in pairs(Types) do
+  Types[v] = k
+end
 
 return Types

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -278,7 +278,19 @@ function utils.execute(cmd, env_script, env, args, cwd, executor, callback, cmak
         if code == 0 then
           callback(Result:new(Types.SUCCESS, nil, nil))
         else
-          callback(Result:new(Types.ANOTHER_JOB_RUNNING, nil, "Process exited with code " .. code))
+          callback(
+            Result:new(
+              Types.CMAKE_RUN_FAILED,
+              nil,
+              string.format(
+                "Process %s %s (cwd=%s) exited with code %d",
+                cmd,
+                table.concat(args, " "),
+                cwd,
+                code
+              )
+            )
+          )
         end
       end
     end, notify_update_line)

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -183,9 +183,9 @@ end
 ---@param args table arguments to the executable
 ---@param cwd string the directory to run in
 ---@param runner runner_conf the executor or runner
----@param on_success nil|function extra arguments, f.e on_success is a callback to be called when the process finishes
+---@param callback nil|function extra arguments, f.e on_success is a callback to be called when the process finishes
 ---@return nil
-function utils.run(cmd, env_script, env, args, cwd, runner, on_success, cmake_notifications)
+function utils.run(cmd, env_script, env, args, cwd, runner, callback, cmake_notifications)
   -- save all
   vim.cmd("silent exec " .. '"wall"')
 
@@ -219,8 +219,12 @@ function utils.run(cmd, env_script, env, args, cwd, runner, on_success, cmake_no
       { icon = icon, replace = notification.notification.id, timeout = 3000 }
     )
     notification.notification = {} -- reset and stop update_spinner
-    if code == 0 and on_success then
-      on_success()
+    if type(callback) == "function" then
+      if code == 0 then
+        callback(Result:new(Types.SUCCESS, nil, nil))
+      else
+        callback(Result:new(Types.CMAKE_RUN_FAILED, nil, "Process exited with code " .. code))
+      end
     end
   end, notify_update_line)
 end
@@ -232,9 +236,9 @@ end
 ---@param args table arguments to the executable
 ---@param cwd string the directory to run in
 ---@param executor executor_conf the executor or runner
----@param on_success nil|function extra arguments, f.e on_success is a callback to be called when the process exits with a 0 exit code
+---@param callback nil|fun(cmake.Result) extra arguments, f.e on_success is a callback to be called when the process exits with a 0 exit code
 ---@return nil
-function utils.execute(cmd, env_script, env, args, cwd, executor, on_success, cmake_notifications)
+function utils.execute(cmd, env_script, env, args, cwd, executor, callback, cmake_notifications)
   -- save all
   vim.cmd("silent exec " .. '"wall"')
 
@@ -270,8 +274,12 @@ function utils.execute(cmd, env_script, env, args, cwd, executor, on_success, cm
         { icon = icon, replace = notification.notification.id, timeout = 3000 }
       )
       notification.notification = {} -- reset and stop update_spinner
-      if code == 0 and type(on_success) == "function" then
-        on_success()
+      if type(callback) == "function" then
+        if code == 0 then
+          callback(Result:new(Types.SUCCESS, nil, nil))
+        else
+          callback(Result:new(Types.ANOTHER_JOB_RUNNING, nil, "Process exited with code " .. code))
+        end
       end
     end, notify_update_line)
 end


### PR DESCRIPTION
In this PR I add callback(result) as the last parameter to most API calls, and:
1. Make sure it is always called exactly once, be that in case of success or failure
2. Fix a bug with `Result` type: its `new` method was setting attributes on the class instead of the object
3. Fix a bug with `Types` type: `SUCCESS` was `1` when there are places in code that assume that it is 0
4. Add a couple of error messages

I tested this locally - to an extent, let me know if there is some kind of proper procedure to know it's working.

RESOLVES: #245 