### PR TITLE
feat: add function to retrieve launch arguments

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -923,6 +923,27 @@ function cmake.target_settings(opt)
   end
 end
 
+function cmake.get_launch_args()
+  if utils.has_active_job(config.runner, config.executor) then
+    return
+  end
+
+  local result = utils.get_cmake_configuration(config.cwd)
+  if result.code ~= Types.SUCCESS then
+    log.error(result.message)
+    return
+  end
+
+  local target = cmake.get_launch_target()
+
+  if target == nil then
+    log.warn("No launch target selected!")
+    return
+  end
+
+  return utils.deepcopy(config.target_settings[target].args or {})
+end
+
 function cmake.run_test(opt)
   if utils.has_active_job(config.runner, config.executor) then
     return


### PR DESCRIPTION
The api allows setting the launch argument already, but it lacks an option to retrieve the currently set arguments. 
This commits adds the missing function.
This enables use cases like appending new arguments to or removing some from the previously set ones.