### PR TITLE
feat: add option to not resize the terminal (#247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ require("cmake-tools").setup {
         single_terminal_per_instance = true, -- Single viewport, multiple windows
         single_terminal_per_tab = true, -- Single viewport per tab
         keep_terminal_static_location = true, -- Static location of the viewport if avialable
+        auto_resize = true, -- Resize the terminal if it already exists
 
         -- Running Tasks
         start_insert = false, -- If you want to enter terminal with :startinsert upon using :CMakeRun
@@ -146,6 +147,7 @@ require("cmake-tools").setup {
         single_terminal_per_instance = true, -- Single viewport, multiple windows
         single_terminal_per_tab = true, -- Single viewport per tab
         keep_terminal_static_location = true, -- Static location of the viewport if avialable
+        auto_resize = true, -- Resize the terminal if it already exists
 
         -- Running Tasks
         start_insert = false, -- If you want to enter terminal with :startinsert upon using :CMakeRun

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -62,6 +62,7 @@ local const = {
         single_terminal_per_instance = true, -- Single instance, multiple windows
         single_terminal_per_tab = true, -- Single instance per tab
         keep_terminal_static_location = true, -- Static location of the instance if avialable
+        auto_resize = true, -- Resize the terminal if it already exists
 
         -- Running Tasks
         start_insert = false, -- If you want to enter terminal with :startinsert upon using :CMakeRun
@@ -105,6 +106,7 @@ local const = {
         single_terminal_per_instance = true, -- Single instance, multiple windows
         single_terminal_per_tab = true, -- Single instance per tab
         keep_terminal_static_location = true, -- Static location of the instance if avialable
+        auto_resize = true, -- Resize the terminal if it already exists
 
         -- Running Tasks
         start_insert = false, -- If you want to enter terminal with :startinsert upon using :CMakeRun

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -40,10 +40,12 @@ function _terminal.show(opts)
   if win_id ~= -1 then
     -- The window is alive, so we set buffer in window
     vim.api.nvim_win_set_buf(win_id, _terminal.id)
-    if opts.split_direction == "horizontal" then
-      vim.api.nvim_win_set_height(win_id, opts.split_size)
-    else
-      vim.api.nvim_win_set_width(win_id, opts.split_size)
+    if opts.auto_resize then
+      if opts.split_direction == "horizontal" then
+        vim.api.nvim_win_set_height(win_id, opts.split_size)
+      else
+        vim.api.nvim_win_set_width(win_id, opts.split_size)
+      end
     end
   elseif win_id >= -1 then
     -- The window is not active, we need to create a new buffer
@@ -63,6 +65,11 @@ function _terminal.new_instance(term_name, opts)
   vim.cmd(":" .. opts.split_direction .. " " .. opts.split_size .. "sp | :term") -- Creater terminal in a split
   -- local new_name = vim.fn.fnamemodify(term_name, ":t")                           -- Extract only the terminal name and reassign it
   vim.api.nvim_buf_set_name(vim.api.nvim_get_current_buf(), term_name) -- Set the buffer name
+  if opts.split_direction == "horizontal" then
+    vim.wo.winfixheight = true
+  else
+    vim.wo.winfixwidth = true
+  end
   vim.cmd(":setlocal laststatus=3") -- Let there be a single status/lualine in the neovim instance
 
   -- Renamming a terminal buffer creates a new hidden buffer, so duplicate terminals need to be deleted
@@ -165,10 +172,12 @@ function _terminal.send_data_to_terminal(buffer_idx, cmd, opts)
   if opts and opts.win_id ~= -1 then
     -- The window is alive, so we set buffer in window
     vim.api.nvim_win_set_buf(opts.win_id, buffer_idx)
-    if opts.split_direction == "horizontal" then
-      vim.api.nvim_win_set_height(opts.win_id, opts.split_size)
-    else
-      vim.api.nvim_win_set_width(opts.win_id, opts.split_size)
+    if opts.auto_resize then
+      if opts.split_direction == "horizontal" then
+        vim.api.nvim_win_set_height(opts.win_id, opts.split_size)
+      else
+        vim.api.nvim_win_set_width(opts.win_id, opts.split_size)
+      end
     end
   elseif opts and opts.win_id >= -1 then
     -- The window is not active, we need to create a new buffer
@@ -628,6 +637,7 @@ function _terminal.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output
       split_size = opts.split_size,
       start_insert = opts.start_insert,
       focus = opts.focus,
+      auto_resize = opts.auto_resize,
       do_not_add_newline = opts.do_not_add_newline,
     }
   )


### PR DESCRIPTION
I'm not sure if the option name is fitting. I am open to suggestions.

Open question: Should the `keep_terminal_size` option be `true` per default?