### PR TITLE
feat: improve runner and executer notification handling

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -34,6 +34,8 @@ function cmake.setup(values)
     const.cmake_runner.opts or {}
   )
 
+  require("cmake-tools.notification").setup(const.cmake_notifications)
+
   config = Config:new(const)
 
   -- auto reload previous session
@@ -119,7 +121,7 @@ function cmake.generate(opt, callback)
       end
       cmake.configure_compile_commands()
       cmake.create_regenerate_on_save_autocmd()
-    end, const.cmake_notifications)
+    end)
   end
 
   -- if exists cmake-kits.json, kit is used to set
@@ -181,7 +183,7 @@ function cmake.generate(opt, callback)
     end
     cmake.configure_compile_commands()
     cmake.create_regenerate_on_save_autocmd()
-  end, const.cmake_notifications)
+  end)
 end
 
 --- Clean targets
@@ -208,7 +210,7 @@ function cmake.clean(callback)
     if type(callback) == "function" then
       callback()
     end
-  end, const.cmake_notifications)
+  end)
 end
 
 --- Build this project using the make toolchain of target platform
@@ -276,7 +278,7 @@ function cmake.build(opt, callback)
     if type(callback) == "function" then
       callback()
     end
-  end, const.cmake_notifications)
+  end)
 end
 
 function cmake.quick_build(opt, callback)
@@ -341,8 +343,7 @@ function cmake.install(opt)
     args,
     config.cwd,
     config.executor,
-    nil,
-    const.cmake_notifications
+    nil
   )
 end
 
@@ -421,16 +422,7 @@ function cmake.run(opt)
       local env = environment.get_run_environment(config, opt.target)
       local _args = opt.args and opt.args or config.target_settings[opt.target].args
       local cmd = target_path
-      utils.run(
-        cmd,
-        config.env_script,
-        env,
-        _args,
-        launch_path,
-        config.runner,
-        nil,
-        const.cmake_notifications
-      )
+      utils.run(cmd, config.env_script, env, _args, launch_path, config.runner, nil)
     end)
   else
     local result = config:get_launch_target()
@@ -468,8 +460,7 @@ function cmake.run(opt)
             cmake:get_launch_args(),
             launch_path,
             config.runner,
-            nil,
-            const.cmake_notifications
+            nil
           )
         end
       )

--- a/lua/cmake-tools/notification.lua
+++ b/lua/cmake-tools/notification.lua
@@ -1,33 +1,87 @@
 local has_notify, notify = pcall(require, "notify")
 
-local notification = {
-  notification = {},
-}
-
-function notification.update_spinner() -- update spinner helper function to defer
-  if notification.notification.spinner_idx then
-    local new_spinner = (notification.notification.spinner_idx + 1)
-      % #notification.notification.spinner
-    notification.notification.spinner_idx = new_spinner
-
-    notification.notification.id = notification.notify(nil, notification.notification.level, {
-      title = "CMakeTools",
-      hide_from_history = true,
-      icon = notification.notification.spinner[new_spinner],
-      replace = notification.notification.id,
-    })
-
-    vim.defer_fn(function()
-      notification.update_spinner()
-    end, notification.notification.refresh_rate_ms)
+local function render(self)
+  if self.closed then
+    self.opts.replace = nil
+  else
+    self.opts.replace = self.id
   end
+
+  self.id = notify(self.msg, self.level, self.opts)
+  self.opts.replace = nil
+  self.closed = false
 end
 
-function notification.notify(msg, lvl, opts)
-  if notification.notification.enabled and has_notify then
-    opts.hide_from_history = true
-    return notify(msg, lvl, opts)
-  end
+local config = {}
+local Notification = {}
+
+function Notification.setup(cfg)
+  config = cfg
 end
 
-return notification
+function Notification:new(type)
+  local instance = setmetatable({}, self)
+  self.__index = self
+
+  instance.spinner_idx = 1
+  instance.closed = true
+  instance.enabled = has_notify and config[type].enabled
+
+  instance.spinnerTimer = vim.loop.new_timer()
+
+  return instance
+end
+
+function Notification:startSpinner()
+  if not self.enabled or self.spinnerRunning then
+    return
+  end
+  self.spinnerRunning = true
+  self.spinnerTimer:start(
+    config.refresh_rate_ms,
+    config.refresh_rate_ms,
+    vim.schedule_wrap(function()
+      self.spinner_idx = (self.spinner_idx + 1) % #config.spinner
+
+      self.opts.replace = self.id
+      self.opts.icon = config.spinner[self.spinner_idx]
+      render(self)
+    end)
+  )
+end
+
+function Notification:stopSpinner()
+  self.spinnerRunning = false
+  self.spinnerTimer:stop()
+end
+
+function Notification:notify(msg, level, opts)
+  if not self.enabled then
+    return
+  end
+
+  self.msg = msg or ""
+  self.level = level
+  self.opts = opts or {}
+
+  local on_close = self.opts.on_close
+  local on_open = self.opts.on_open
+
+  self.opts.hide_from_history = true
+  self.opts.title = "CMakeTools"
+  self.opts.on_close = function(win)
+    self.closed = true
+    if on_close then
+      on_close(win)
+    end
+  end
+  self.opts.on_open = function(win)
+    if on_open then
+      on_open(win)
+    end
+  end
+
+  render(self)
+end
+
+return Notification

--- a/lua/cmake-tools/notification.lua
+++ b/lua/cmake-tools/notification.lua
@@ -76,12 +76,25 @@ function Notification:notify(msg, level, opts)
     end
   end
   self.opts.on_open = function(win)
+    self.win = win
+    self.width = vim.api.nvim_win_get_width(win)
     if on_open then
       on_open(win)
     end
   end
 
   render(self)
+
+  -- update the notification width when the message was updated
+  local timeDigits = 8
+  local headlineLength = (self.opts.icon and (#self.opts.icon + 1) or 0)
+    + #self.opts.title
+    + 3 -- padding between title and time
+    + timeDigits
+
+  if self.width then
+    vim.api.nvim_win_set_width(self.win, math.max(#self.msg + 1, headlineLength))
+  end
 end
 
 return Notification


### PR DESCRIPTION
With the new approach we get rid of the global states managed in the notifications table. Everything is capsulated within the created notification instance.
That also allows to fix an issue where a notification is dismissed while a build process is still ongoing and the spinner should be updated. Updating the spinner fails, because the notification timed out and got dismissed, resulting in a repeating "No Matching notification to replace found" error.
The new instance based approach tracks the shown notification and replaces any existing notification when the message is updated. If the notification times out and is dismissed, the instance will create a new notification automatically.

Additionally, the notification window is resized automatically to match the updated contents, if the displayed message changes