### PR TITLE
Presets refactoring

### DIFF
--- a/docs/cmake_presets.md
+++ b/docs/cmake_presets.md
@@ -12,4 +12,4 @@ Read more about CMake presets from [CMake docs](https://cmake.org/cmake/help/lat
 2. [Package Preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#package-preset) is not supported.
 3. [Workflow Preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#workflow-preset) is not supported.
 4. [Condition](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#condition) mostly supported. Types `matches` and `notMatches` currently not supported due to lua's differences in regex capabilities
-5. Some macros not supported yet: `$penv{<variable-name>}`, `$vendor{<macro-name>}`
+5. Some macros not supported yet: `$vendor{<macro-name>}`

--- a/docs/cmake_presets.md
+++ b/docs/cmake_presets.md
@@ -11,5 +11,5 @@ Read more about CMake presets from [CMake docs](https://cmake.org/cmake/help/lat
 1. [Test Preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#test-preset) is not supported.
 2. [Package Preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#package-preset) is not supported.
 3. [Workflow Preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#workflow-preset) is not supported.
-4. [Condition](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#condition) is not supported.
-5. Some macros not supported yet: `$env{<variable-name>}`, `$penv{<variable-name>}`, `$vendor{<macro-name>}`
+4. [Condition](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#condition) mostly supported. Types `matches` and `notMatches` currently not supported due to lua's differences in regex capabilities
+5. Some macros not supported yet: `$penv{<variable-name>}`, `$vendor{<macro-name>}`

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -23,6 +23,7 @@ local Config = {
     use_preset = true,
     generate_options = {},
     build_options = {},
+    show_disabled_build_presets = true,
   }, -- general config
   target_settings = {}, -- target specific config
   executor = nil,
@@ -40,6 +41,8 @@ function Config:new(const)
   obj.base_settings.generate_options = const.cmake_generate_options
   obj.base_settings.build_options = const.cmake_build_options
   obj.base_settings.use_preset = const.cmake_use_preset
+
+  obj.base_settings.show_disabled_build_presets = const.cmake_show_disabled_build_presets
 
   obj.executor = const.cmake_executor
   obj.runner = const.cmake_runner
@@ -132,6 +135,10 @@ end
 
 function Config:build_options()
   return self.base_settings.build_options and self.base_settings.build_options or {}
+end
+
+function Config:show_disabled_build_presets()
+  return self.base_settings.show_disabled_build_presets
 end
 
 function Config:generate_build_directory()

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -6,6 +6,7 @@ local const = {
   cmake_regenerate_on_save = true, -- auto generate when save CMakeLists.txt
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- this will be passed when invoke `CMakeGenerate`
   cmake_build_options = {}, -- this will be passed when invoke `CMakeBuild`
+  cmake_show_disabled_build_presets = true,
   cmake_build_directory = function()
     if osys.iswin32 then
       return "out\\${variant:buildType}"

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1408,10 +1408,16 @@ function cmake.create_regenerate_on_save_autocmd()
         local buf = vim.api.nvim_get_current_buf()
         -- Check if buffer is actually modified, and only if it is modified,
         -- execute the :CMakeGenerate, otherwise return. This is to avoid unnecessary regenerattion
-        local buf_modified = vim.api.nvim_buf_get_option(buf, "modified")
-        if buf_modified then
-          cmake.generate({ bang = false, fargs = {} }, nil)
-          config:update_targets()
+        if vim.api.nvim_buf_get_option(buf, "modified") then
+          vim.api.nvim_create_autocmd("BufWritePost", {
+            group = group,
+            once = true,
+            buffer = buf,
+            callback = function()
+              cmake.generate({ bang = false, fargs = {} }, nil)
+              config:update_targets()
+            end,
+          })
         end
       end,
     })

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -251,9 +251,17 @@ function cmake.clean(callback)
     return
   end
 
+  local path = Path:new(
+    utils.transform_path(config:build_directory_path(), config.executor.name == "quickfix")
+  )
+  if not (path / "CMakeCache.txt"):exists() then
+    -- no need to clean up as we do not have a cache
+    return
+  end
+
   local args = {
     "--build",
-    utils.transform_path(config:build_directory_path(), config.executor.name == "quickfix"),
+    path.filename,
     "--target",
     "clean",
   }

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -797,7 +797,8 @@ function cmake.select_build_preset(callback)
   -- if exists presets
   if Presets.exists(config.cwd) then
     local presets = Presets:parse(config.cwd)
-    local build_preset_names = presets:get_build_preset_names()
+    local build_preset_names =
+      presets:get_build_preset_names({ include_disabled = config:show_disabled_build_presets() })
     build_preset_names = vim.list_extend(build_preset_names, { "None" })
     local format_preset_name = function(p_name)
       if p_name == "None" then

--- a/lua/cmake-tools/preset.lua
+++ b/lua/cmake-tools/preset.lua
@@ -11,6 +11,10 @@ local function expandMacro(self, str)
     return self.environment[envVar] or vim.env[envVar] or ""
   end)
 
+  str = str:gsub("%$penv{(.-)}", function(envVar)
+    return vim.env[envVar] or ""
+  end)
+
   -- macro expansion
   local source_path = Path:new(self.cwd)
   local source_relative = vim.fn.fnamemodify(self.cwd, ":t")
@@ -185,6 +189,10 @@ local function resolveEnvVars(self)
       visitedKeys[envVar] = nil -- Unmark the key after resolving
 
       return ret
+    end)
+
+    return value:gsub("%$penv{(.-)}", function(envVar)
+      return vim.env[envVar] or ""
     end)
   end
 

--- a/lua/cmake-tools/preset.lua
+++ b/lua/cmake-tools/preset.lua
@@ -1,0 +1,141 @@
+local Path = require("plenary.path")
+
+local Preset = {}
+
+local function createInstance(self, obj, get_preset)
+  local instance = setmetatable(obj or {}, self)
+  self.__index = self
+  instance.inheritedPresets = {}
+
+  if type(instance.inherits) == "string" then
+    local nextPreset = get_preset(instance.inherits)
+    if nextPreset then
+      local p = createInstance(self, nextPreset, get_preset)
+      instance.binaryDir = instance.binaryDir or p.binaryDir
+      table.insert(instance.inheritedPresets, p)
+    end
+  else
+    if type(instance.inherits) == "table" then
+      for _, inherited in ipairs(instance.inherits) do
+        local nextPreset = get_preset(inherited)
+        if nextPreset then
+          local p = createInstance(self, nextPreset, get_preset)
+          instance.binaryDir = instance.binaryDir or p.binaryDir
+          table.insert(instance.inheritedPresets, p)
+        end
+      end
+    end
+  end
+
+  return instance
+end
+
+local function resolveEnviroment(self)
+  local function build(bPreset)
+    local env = bPreset.environment or {}
+    for _, inherited in ipairs(bPreset.inheritedPresets) do
+      env = vim.tbl_deep_extend("keep", env, build(inherited))
+    end
+
+  -- macro expansion
+  local source_path = Path:new(self.cwd)
+  local source_relative = vim.fn.fnamemodify(self.cwd, ":t")
+  str = str:gsub("${sourceDir}", ".") -- sourceDir is relative to the CMakePresests.json file, and should be relative
+  str = str:gsub("${sourceParentDir}", source_path:parent().filename)
+  str = str:gsub("${sourceDirName}", source_relative)
+  str = str:gsub("${presetName}", self.name)
+  if self.generator then
+    str = str:gsub("${generator}", self.generator)
+  end
+
+  local function resolveEnvVars(tbl)
+    local function resolve(value, visitedKeys)
+      if type(value) ~= "string" then
+        return value -- Only resolve string values
+      end
+
+      -- Resolve placeholders in the format $env{key}
+      return value:gsub("%$env{(.-)}", function(envVar)
+        -- Prevent infinite recursion: a key should not refer to itself
+        if visitedKeys[envVar] then
+          error("Circular reference detected for key: " .. envVar)
+        end
+
+        local envValue = tbl[envVar]
+        if envValue == nil then
+          return vim.env[envVar] or ""
+        end
+
+        -- Mark this key as visited to detect circular references
+        visitedKeys[envVar] = true
+        local ret = resolve(envValue, visitedKeys)
+        visitedKeys[envVar] = nil -- Unmark the key after resolving
+
+        return ret
+      end)
+    end
+
+    -- Loop through all the keys in the table and resolve their values
+    local result = {}
+    for key, value in pairs(tbl) do
+      result[key] = resolve(value, { [key] = true })
+    end
+
+    return result
+  end
+
+  self.environment = resolveEnvVars(build(self))
+end
+
+local function envLookup(str, env)
+  return str:gsub("%$env{(.-)}", function(envVar)
+    return env[envVar] or vim.env[envVar] or ""
+  end)
+end
+
+local function resolveBuildDir(self)
+  if not self.binaryDir then
+    return
+  end
+  self.buildDir = envLookup(self.binaryDir, self.environment)
+
+  -- macro expansion
+  local source_path = Path:new(self.cwd)
+  local source_relative = vim.fn.fnamemodify(self.cwd, ":t")
+  self.buildDir = self.buildDir:gsub("${sourceDir}", ".") -- sourceDir is relative to the CMakePresests.json file, and should be relative
+  self.buildDir = self.buildDir:gsub("${sourceParentDir}", source_path:parent().filename)
+  self.buildDir = self.buildDir:gsub("${sourceDirName}", source_relative)
+  self.buildDir = self.buildDir:gsub("${selfName}", self.name)
+  if self.generator then
+    self.buildDir = self.buildDir:gsub("${generator}", self.generator)
+  end
+  self.buildDir = self.buildDir:gsub("${hostSystemName}", vim.loop.os_uname().sysname)
+  self.buildDir = self.buildDir:gsub("${fileDir}", source_path.filename)
+  self.buildDir = self.buildDir:gsub("${dollar}", "$")
+  self.buildDir = self.buildDir:gsub("${pathListSep}", "/")
+
+  self.buildDir = vim.fn.fnamemodify(self.buildDir, ":.")
+end
+
+local function resolveCacheVariables(self)
+  for _, var in pairs(self.cacheVariables) do
+    var = envLookup(var, self.environment)
+  end
+end
+
+function Preset:new(cwd, obj, get_preset)
+  local instance = createInstance(self, obj, get_preset)
+  instance.cwd = cwd
+
+  resolveEnviroment(instance)
+  resolveBuildDir(instance)
+  resolveCacheVariables(instance)
+
+  return instance
+end
+
+function Preset:get_build_type()
+  return self.cacheVariables and self.cacheVariables.CMAKE_BUILD_TYPE or "Debug"
+end
+
+return Preset

--- a/lua/cmake-tools/preset.lua
+++ b/lua/cmake-tools/preset.lua
@@ -87,35 +87,38 @@ local function buildEnvironment(self)
   self.environment = resolveEnvVars(build(self))
 end
 
-local function envLookup(str, env)
-  return str:gsub("%$env{(.-)}", function(envVar)
-    return env[envVar] or vim.env[envVar] or ""
+local function expandMacro(self, str)
+  if type(str) ~= "string" then
+    return str
+  end
+
+  str = str:gsub("%$env{(.-)}", function(envVar)
+    return self.environment[envVar] or vim.env[envVar] or ""
   end)
+
+  -- macro expansion
+  local source_path = Path:new(self.cwd)
+  local source_relative = vim.fn.fnamemodify(self.cwd, ":t")
+  str = str:gsub("${sourceDir}", ".") -- sourceDir is relative to the CMakePresests.json file, and should be relative
+  str = str:gsub("${sourceParentDir}", source_path:parent().filename)
+  str = str:gsub("${sourceDirName}", source_relative)
+  str = str:gsub("${presetName}", self.name)
+  if self.generator then
+    str = str:gsub("${generator}", self.generator)
+  end
+  str = str:gsub("${hostSystemName}", vim.loop.os_uname().sysname)
+  str = str:gsub("${fileDir}", source_path.filename)
+  str = str:gsub("${dollar}", "$")
+  str = str:gsub("${pathListSep}", "/")
+
+  return str
 end
 
-local function resolveBuildDir(self, cwd)
+local function resolveBuildDir(self)
   if not self.binaryDir then
     return
   end
-  self.binaryDirExpanded = envLookup(self.binaryDir, self.environment)
-
-  -- macro expansion
-  local source_path = Path:new(cwd)
-  local source_relative = vim.fn.fnamemodify(cwd, ":t")
-  self.binaryDirExpanded = self.binaryDirExpanded:gsub("${sourceDir}", ".") -- sourceDir is relative to the CMakePresests.json file, and should be relative
-  self.binaryDirExpanded =
-    self.binaryDirExpanded:gsub("${sourceParentDir}", source_path:parent().filename)
-  self.binaryDirExpanded = self.binaryDirExpanded:gsub("${sourceDirName}", source_relative)
-  self.binaryDirExpanded = self.binaryDirExpanded:gsub("${selfName}", self.name)
-  if self.generator then
-    self.binaryDirExpanded = self.binaryDirExpanded:gsub("${generator}", self.generator)
-  end
-  self.binaryDirExpanded =
-    self.binaryDirExpanded:gsub("${hostSystemName}", vim.loop.os_uname().sysname)
-  self.binaryDirExpanded = self.binaryDirExpanded:gsub("${fileDir}", source_path.filename)
-  self.binaryDirExpanded = self.binaryDirExpanded:gsub("${dollar}", "$")
-  self.binaryDirExpanded = self.binaryDirExpanded:gsub("${pathListSep}", "/")
-
+  self.binaryDirExpanded = expandMacro(self, self.binaryDir)
   self.binaryDirExpanded = vim.fn.fnamemodify(self.binaryDirExpanded, ":.")
 end
 
@@ -134,12 +137,132 @@ end
 
 local function resolveCacheVariables(self)
   for key, var in pairs(self.cacheVariables or {}) do
-    self.cacheVariables[key] = envLookup(var, self.environment)
+    self.cacheVariables[key] = expandMacro(self, var)
   end
+end
+
+local function resolveConditions(self)
+  local function evalCondition(preset)
+    local function eval(cond)
+      if not type(cond) == "table" then
+        error("condition field has to be a JSON object")
+      end
+
+      local ctype = cond.type
+      if not ctype then
+        error("condition field missing required field 'type'")
+      end
+
+      local function equals()
+        if type(cond.lhs) ~= "string" then
+          error("condition field missing required string field 'lhs'")
+        elseif type(cond.rhs) ~= "string" then
+          error("condition field missing required string field 'rhs'")
+        end
+        return expandMacro(self, cond.lhs) == expandMacro(self, cond.rhs)
+      end
+
+      local function inList()
+        if type(cond.string) ~= "string" then
+          error("condition field missing required string field 'string'")
+        end
+        if not vim.isarray(cond.list) then
+          error("condition field missing required array field 'list'")
+        end
+
+        cond.string = expandMacro(self, cond.string)
+
+        for _, entry in ipairs(cond.list) do
+          if type(entry) ~= "string" then
+            error("list field must be of type string")
+          end
+          if cond.string == expandMacro(self, self, entry) then
+            return true
+          end
+        end
+
+        return false
+      end
+
+      if ctype == "const" then
+        if not type(cond.value) == "bool" then
+          error("condition type 'const' requires a boolean field 'value'")
+        end
+        return cond.value
+      elseif ctype == "equals" then
+        return equals()
+      elseif ctype == "notEquals" then
+        return not equals()
+      elseif ctype == "inList" then
+        return inList()
+      elseif ctype == "notInList" then
+        return not inList()
+      elseif ctype == "anyOf" then
+        if not vim.isarray(cond.conditions) then
+          error("conditions field must be of type array")
+        end
+        for _, nestedCond in ipairs(cond.conditions) do
+          if eval(nestedCond) then
+            return true
+          end
+        end
+        return true
+      elseif ctype == "allOf" then
+        if not vim.isarray(cond.conditions) then
+          error("conditions field must be of type array")
+        end
+        for _, nestedCond in ipairs(cond.conditions) do
+          if not eval(nestedCond) then
+            return false
+          end
+        end
+        return true
+      elseif ctype == "not" then
+        if not type(cond.condition) == "table" then
+          error("condition field 'condition' must be of type object")
+        end
+        return not eval(cond.condition)
+      else
+        -- matches and notMatches currently not supported due to lua's limited regex support
+        -- for now, lets just pass the check and let cmake handle the rest
+        return true
+      end
+    end
+
+    if not preset.condition then
+      return
+    end
+    return eval(preset.condition)
+  end
+
+  local function checkPreset(preset)
+    local queue = { preset }
+    local i = 0
+
+    while #queue ~= i do
+      local current = queue[i + 1]
+      local ret = evalCondition(current)
+      if ret ~= nil then
+        return ret
+      end
+
+      for _, nestedPreset in ipairs(current.inheritedPresets) do
+        table.insert(queue, nestedPreset)
+      end
+      i = i + 1
+    end
+
+    return nil
+  end
+  local enabled = checkPreset(self)
+
+  self.disabled = (enabled ~= nil) and (enabled == false)
 end
 
 function Preset:new(cwd, obj, get_preset)
   local instance = createInstance(self, obj, get_preset)
+  instance.environment = resolveEnvVars(instance.environment)
+  instance.cwd = cwd
 
   -- gather all environment variables in the top preset
   buildEnvironment(instance)
@@ -148,6 +271,9 @@ function Preset:new(cwd, obj, get_preset)
 
   resolveBuildDir(instance, cwd)
   resolveCacheVariables(instance)
+
+  -- We have to resolve the environment first as the condition might depend on envVars
+  resolveConditions(instance)
 
   return instance
 end

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -216,7 +216,16 @@ end
 -- Retrieve build directory from preset
 function presets.get_build_dir(preset, cwd)
   -- check if this preset is extended
+  local configurePresets = get_preset_data(cwd)["configurePresets"]
+
   local function helper(p_preset)
+    local function findPreset(name)
+      for _, entry in pairs(configurePresets) do
+        if entry.name == name then
+          return entry
+        end
+      end
+    end
     if not p_preset then
       return ""
     end
@@ -229,7 +238,7 @@ function presets.get_build_dir(preset, cwd)
     local inherits = p_preset.inherits
     if inherits then
       local set_dir_by_parent = function(parent)
-        local ppreset = presets.get_preset_by_name(parent, "configurePresets", cwd)
+        local ppreset = findPreset(parent)
         if ppreset ~= nil then
           local ppreset_build_dir = helper(ppreset)
           if ppreset_build_dir ~= "" then

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -1,26 +1,5 @@
 local Path = require("plenary.path")
-
-local presets = {}
-
-function presets.check(cwd)
-  local files = vim.fn.readdir(cwd)
-  local presetFiles = {}
-  for _, f in ipairs(files) do -- iterate over files in current directory
-    if
-      f == "CMakePresets.json"
-      or f == "CMakeUserPresets.json"
-      or f == "cmake-presets.json"
-      or f == "cmake-user-presets.json"
-    then -- if a preset file is found
-      table.insert(presetFiles, tostring(Path:new(cwd, f)))
-    end
-  end
-  table.sort(presetFiles, function(a, b)
-    return a > b
-  end)
-
-  return unpack(presetFiles)
-end
+local Preset = require("cmake-tools.preset")
 
 -- Extends (or creates a new) key-value pair in [dest] in which the
 -- key is [key] and the value is the resulting list table of merging
@@ -87,9 +66,9 @@ local function decode(file)
   return data
 end
 
--- Reads the CMakePresets.json and CMakeUserPresets.json and merges them
--- if both are found
-local function get_preset_data(cwd)
+local Presets = {}
+
+function Presets:parse(cwd)
   local function merge_presets(lhs, rhs)
     local ret = vim.deepcopy(lhs)
     for k, v2 in pairs(rhs) do
@@ -115,240 +94,120 @@ local function get_preset_data(cwd)
     return ret
   end
 
-  local userPresetFile, presetFile = presets.check(cwd)
-  if not userPresetFile then
-    return nil
-  end
-  local data = decode(userPresetFile)
-  if data == nil then
+  local userPresetFile, presetFile = self.find_preset_files(cwd)
+  local instance = setmetatable({}, self)
+
+  self.__index = self
+
+  -- TODO: make data the base of our metatable
+  instance.data = decode(userPresetFile)
+  if instance.data == nil then
     -- this can not happen as decode will error out
-    return nil
+    return instance
   end
 
   if presetFile then
     local presetData = decode(presetFile)
     if presetData then
-      return merge_presets(data, presetData)
+      instance.data = merge_presets(instance.data, presetData)
     end
   end
 
-  return data
+  local function createPreset(obj)
+    local function getPreset(name)
+      return instance:get_configure_preset(name, { include_hidden = true })
+    end
+    return Preset:new(cwd, obj, getPreset)
+  end
+
+  for _, preset in ipairs(instance.data.configurePresets) do
+    preset = createPreset(preset)
+  end
+
+  return instance
 end
 
--- Retrieve all presets with type
+-- Retrieve all preset names for the given type
 -- @param type: `buildPresets` or `configurePresets`
 -- @param {opts}: include_hidden(bool|nil).
 --                If true, hidden preset will be included in result.
 -- @returns : list with all preset names
-function presets.parse(type, opts, cwd)
+function Presets:get_preset_names(type, opts)
   local options = {}
-  local data = get_preset_data(cwd)
-
-  if data == nil then
-    return options
-  end
-
   local include_hidden = opts and opts.include_hidden
 
-  if data[type] then
-    for _, v in pairs(data[type]) do
-      if include_hidden or not v["hidden"] then
-        table.insert(options, v["name"])
+  if self.data[type] then
+    for _, v in pairs(self.data[type]) do
+      if include_hidden or not v.hidden then
+        table.insert(options, v.name)
       end
     end
   end
   return options
 end
 
--- Retrieve all presets with type
+-- Retrieve all presets mapped to their name for the given type
 -- @param type: `buildPresets` or `configurePresets`
 -- @param {opts}: include_hidden(bool|nil).
 --                If true, hidden preset will be included in result.
 -- @returns : table with preset name as key and preset content as value
-function presets.parse_name_mapped(type, opts, cwd)
+function Presets:get_presets_by_name(type, opts)
   local options = {}
-  local data = get_preset_data(cwd)
-
-  if data == nil then
-    return options
-  end
-
   local include_hidden = opts and opts.include_hidden
 
-  if data[type] then
-    for _, v in pairs(data[type]) do
-      if include_hidden or not v["hidden"] then
-        options[v["name"]] = v
+  if self.data[type] then
+    for _, v in pairs(self.data[type]) do
+      if include_hidden or not v.hidden then
+        options[v.name] = v
       end
     end
   end
   return options
 end
 
--- Retrieve preset by name and type
--- @param name: from `name` option
--- @param type: `buildPresets` or `configurePresets`
-function presets.get_preset_by_name(name, type, cwd)
-  local data = get_preset_data(cwd)
-
-  if not data then
-    return nil
-  end
-
-  if data[type] then
-    for _, v in pairs(data[type]) do
+local function get_preset(name, tbl, opts)
+  local include_hidden = opts and opts.include_hidden
+  if tbl then
+    for _, v in pairs(tbl) do
       if v.name == name then
-        return v
+        if include_hidden or not v.hidden then
+          return v
+        end
       end
     end
   end
-  return nil
 end
 
--- Retrieve build type from preset
-function presets.get_build_type(preset)
-  if preset and preset.cacheVariables and preset.cacheVariables.CMAKE_BUILD_TYPE then
-    return preset.cacheVariables.CMAKE_BUILD_TYPE
-  end
-  return "Debug"
+function Presets:get_configure_preset(name, opts)
+  return get_preset(name, self.data.configurePresets, opts)
 end
 
--- Retrieve build directory from preset
-function presets.get_build_dir(preset, cwd)
-  -- check if this preset is extended
-  local configurePresets = get_preset_data(cwd)["configurePresets"]
-  local function findPreset(name)
-    for _, entry in pairs(configurePresets) do
-      if entry.name == name then
-        return entry
-      end
+function Presets:get_build_preset(name, opts)
+  return get_preset(name, self.data.buildPresets, opts)
+end
+
+function Presets.find_preset_files(cwd)
+  local files = vim.fn.readdir(cwd)
+  local presetFiles = {}
+  for _, f in ipairs(files) do -- iterate over files in current directory
+    if
+      f == "CMakePresets.json"
+      or f == "CMakeUserPresets.json"
+      or f == "cmake-presets.json"
+      or f == "cmake-user-presets.json"
+    then -- if a preset file is found
+      table.insert(presetFiles, tostring(Path:new(cwd, f)))
     end
   end
-
-  -- Interates through all inherited presets and builds the environment table
-  local function buildEnvTable(p_preset)
-    local env = p_preset.environment or {}
-    if p_preset.inherits then
-      if type(p_preset.inherits) == "table" then
-        for _, parent in ipairs(p_preset.inherits) do
-          -- retrieve its parent preset, keep already seend variables
-          env = vim.tbl_deep_extend("keep", env, buildEnvTable(findPreset(parent)))
-        end
-      elseif type(p_preset.inherits) == "string" then
-        env = vim.tbl_deep_extend("keep", env, buildEnvTable(findPreset(p_preset.inherits)))
-      end
-    end
-    return env
-  end
-
-  -- Resolves dependend environment variables and replaces $env{<var>} with
-  -- the value for <var>
-  local function resolveEnvVars(tbl)
-    local function resolve(value, visitedKeys)
-      if type(value) ~= "string" then
-        return value -- Only resolve string values
-      end
-
-      -- Resolve placeholders in the format $env{key}
-      return value:gsub("%$env{(.-)}", function(envVar)
-        -- Prevent infinite recursion: a key should not refer to itself
-        if visitedKeys[envVar] then
-          error("Circular reference detected for key: " .. envVar)
-        end
-
-        local envValue = tbl[envVar]
-        if envValue == nil then
-          return vim.env[envVar] or ""
-        end
-
-        -- Mark this key as visited to detect circular references
-        visitedKeys[envVar] = true
-        local ret = resolve(envValue, visitedKeys)
-        visitedKeys[envVar] = nil -- Unmark the key after resolving
-
-        return ret
-      end)
-    end
-
-    local result = {}
-    for key, value in pairs(tbl) do
-      result[key] = resolve(value, { [key] = true })
-    end
-
-    return result
-  end
-
-  local function helper(p_preset)
-    if not p_preset then
-      return ""
-    end
-
-    if p_preset.binaryDir then
-      return p_preset.binaryDir
-    end
-
-    local build_dir = p_preset.name
-    local inherits = p_preset.inherits
-    if inherits then
-      local set_dir_by_parent = function(parent)
-        local ppreset = findPreset(parent)
-        if ppreset ~= nil then
-          local ppreset_build_dir = helper(ppreset)
-          if ppreset_build_dir ~= "" then
-            return ppreset_build_dir
-          end
-        end
-        return nil
-      end
-      -- According to `https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html`,
-      -- `inherits` field may be a list of strings or a single string.
-      -- Check type then act.
-      if type(inherits) == "table" then
-        for _, parent in ipairs(inherits) do
-          -- retrieve its parent preset
-          local dir = set_dir_by_parent(parent)
-          if dir then
-            build_dir = dir
-            break
-          end
-        end
-      elseif type(inherits) == "string" then
-        build_dir = set_dir_by_parent(inherits) or build_dir
-      end
-    end
-    return build_dir
-  end
-
-  local build_dir = helper(preset)
-  local no_expand_build_dir = build_dir
-
-  -- macro expansion
-  local source_path = Path:new(cwd)
-  local source_relative = vim.fn.fnamemodify(cwd, ":t")
-
-  -- environment variables
-  local env = resolveEnvVars(buildEnvTable(preset))
-
-  -- resolve environment variables first as they might contain other macros
-  build_dir = build_dir:gsub("%$env{(.-)}", function(envVar)
-    return env[envVar] or vim.env[envVar] or ""
+  table.sort(presetFiles, function(a, b)
+    return a > b
   end)
 
-  build_dir = build_dir:gsub("${sourceDir}", ".") -- sourceDir is relative to the CMakePresests.json file, and should be relative
-  build_dir = build_dir:gsub("${sourceParentDir}", source_path:parent().filename)
-  build_dir = build_dir:gsub("${sourceDirName}", source_relative)
-  build_dir = build_dir:gsub("${presetName}", preset.name)
-  if preset.generator then
-    build_dir = build_dir:gsub("${generator}", preset.generator)
-  end
-  build_dir = build_dir:gsub("${hostSystemName}", vim.loop.os_uname().sysname)
-  build_dir = build_dir:gsub("${fileDir}", source_path.filename)
-  build_dir = build_dir:gsub("${dollar}", "$")
-  build_dir = build_dir:gsub("${pathListSep}", "/")
-
-  build_dir = vim.fn.fnamemodify(build_dir, ":.")
-
-  return build_dir, no_expand_build_dir
+  return unpack(presetFiles)
 end
 
-return presets
+function Presets.exists(cwd)
+  return Presets.find_preset_files(cwd) ~= nil
+end
+
+return Presets

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -133,8 +133,10 @@ local function get_preset_names(presets, opts)
 
   if presets then
     for _, v in pairs(presets) do
-      if include_hidden or not v.hidden then
-        table.insert(options, v.name)
+      if not v.disabled then
+        if include_hidden or not v.hidden then
+          table.insert(options, v.name)
+        end
       end
     end
   end
@@ -154,8 +156,10 @@ local function get_preset(name, tbl, opts)
   if tbl then
     for _, v in pairs(tbl) do
       if v.name == name then
-        if include_hidden or not v.hidden then
-          return v
+        if not v.disabled then
+          if include_hidden or not v.hidden then
+            return v
+          end
         end
       end
     end


### PR DESCRIPTION
This PR comes with an overhaul of the preset parsing / handling. 
It contains the followin changes:

### configure presets are now actual class instances with encapsulated data.
This is the enablement for the other features contained in the PR. 

### reduced access to disk 
As the configure preset data is now encapsulated in the class instance, it is not necessary to read the preset file(s) multiple times to access different parts of the preset. 
Previously, the most extreme case was determining the build_dir, which read the preset file for each inherited preset.
The new approach reads the file exactly once and parses the data into a hierarchy of preset instances.

### presets from CMakePrests.json honored (#227)
If a CMakeUserPreset.json is found, the old implementation did not look up neither the inherited presets nor non-hidden presets from a CMakePreset.json file.
The new implementation reads both files and combines them into one data structure. The values from the CMakeUserPreset.json take precedence.


### environment variable support
The new instance based approach allows building a environment table. This enables resolving environment variables (`$env{<var>}` and `$penv{<var>}`) for the environment table itself, but also other fields. 
MacroExpansion (including envVars) currently supported for the binaryDir, condition variables and CacheVariables.

### conditions 
This PR adds support for conditions (except for `matches` and `notMatches` due to lua's regex capabilities).
If a preset is disabled via its condition, it is removed from the list of available configure presets and automatically deselected, if it is the currently selected configure preset.
If a configure preset and thereby the corresponding, currently selected build preset becomes available again, the configure preset is automatically selected again (based on the currently selected build preset).

Also included is a config option to hide any build preset which refers to a disabled configure preset. This is not standard cmake behaviour, but I think it is quite nice to be able to hide build preset's whose configure presets can not be used anyways.
Currently, this option is added to the `base_settings` and saved per session. This allows defining a default in the config, but re-configure it for inidividual projects, if needed.


### misc
This PR prevents an error which occurs when `cmake --target clean` is issued if no cache is available. Now, the cache is only cleared, if it actually exists.

I moved the call to `generate` from `BufWritePre` to `BufWritePost` as this caused an error when a preset got disabled in the currently opened CMake[User]Preset.json file. `generate` would prompt the user to select another configure preset while the buffer is being written. This caused the preset selection to lose focus and become untargetable. Running `generate` after the buffer was written fixes this issue.
