### PR TITLE
fix: register scratch buffer after changing cwd

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1189,6 +1189,7 @@ function cmake.select_cwd(cwd_path)
         config.cwd = vim.fn.resolve(input)
         cmake.register_autocmd()
         cmake.register_autocmd_provided_by_users()
+        cmake.register_scratch_buffer(config.executor.name, config.runner.name)
         --	end
         cmake.generate({ bang = false, fargs = {} }, nil)
       end)
@@ -1197,6 +1198,7 @@ function cmake.select_cwd(cwd_path)
     config.cwd = vim.fn.resolve(cwd_path.args)
     cmake.register_autocmd()
     cmake.register_autocmd_provided_by_users()
+    cmake.register_scratch_buffer(config.executor.name, config.runner.name)
     cmake.generate({ bang = false, fargs = {} }, nil)
   end
 end

--- a/lua/cmake-tools/scratch.lua
+++ b/lua/cmake-tools/scratch.lua
@@ -4,6 +4,10 @@ local scratch = {
 }
 
 function scratch.create(executor, runner)
+  if scratch.buffer ~= nil then
+    return
+  end
+
   scratch.buffer = vim.api.nvim_create_buf(true, true) -- can be search, and is a scratch buffer
   vim.api.nvim_buf_set_name(scratch.buffer, scratch.name)
   vim.api.nvim_buf_set_lines(scratch.buffer, 0, 0, false, {


### PR DESCRIPTION
When starting vim in a project that has a top-level CMakeLists.txt in a subdirectory, then calling :CMakeSelectCwd {subdir} writing to the scratch buffer will fail because it doesn't exist yet. Make sure to register the buffer after changing cwd.