### PR TITLE
append `build_options` last so backend args pass correctly

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -257,8 +257,6 @@ function cmake.build(opt, callback)
     }
   end
 
-  vim.list_extend(args, config:build_options())
-
   if opt.target ~= nil then
     vim.list_extend(args, { "--target", opt.target })
     vim.list_extend(args, fargs)
@@ -269,6 +267,8 @@ function cmake.build(opt, callback)
     vim.list_extend(args, { "--target", config.build_target })
     vim.list_extend(args, fargs)
   end
+
+  vim.list_extend(args, config:build_options())
 
   local env = environment.get_build_environment(config)
   local cmd = const.cmake_command


### PR DESCRIPTION
append the `build_options` args last so that passing `"--", "<some backend arg>"` works correctly

Fix for #249 & #261