### PR TITLE
fix: incorrect macro expansion for `$(hostSystemName}` on Windows

### DIFF
--- a/lua/cmake-tools/preset.lua
+++ b/lua/cmake-tools/preset.lua
@@ -1,4 +1,5 @@
 local Path = require("plenary.path")
+local osys = require("cmake-tools.osys")
 
 local Preset = {}
 
@@ -25,7 +26,7 @@ local function expandMacro(self, str)
   if self.generator then
     str = str:gsub("${generator}", self.generator)
   end
-  str = str:gsub("${hostSystemName}", vim.loop.os_uname().sysname)
+  str = str:gsub("${hostSystemName}", osys.iswin32 and "Windows" or vim.loop.os_uname().sysname)
   str = str:gsub("${fileDir}", source_path.filename)
   str = str:gsub("${dollar}", "$")
   str = str:gsub("${pathListSep}", "/")


### PR DESCRIPTION
[Ref](https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_NAME.html)