### PR TITLE
fix: Only switch dir for building with preset

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -342,15 +342,18 @@ function cmake.build(opt, callback)
   end
 
   local args
+  local cwd
   local presets_exists = config.base_settings.use_preset and Presets.exists(config.cwd)
 
   if presets_exists and config.build_preset then
     args = { "--build", "--preset", config.build_preset } -- preset don't need define build dir.
+    cwd = config.cwd
   else
     args = {
       "--build",
       utils.transform_path(config:build_directory_path(), config.executor.name == "quickfix"),
     }
+    cwd = "."
   end
 
   if opt.target ~= nil then
@@ -372,7 +375,7 @@ function cmake.build(opt, callback)
 
   local env = environment.get_build_environment(config)
   local cmd = const.cmake_command
-  return utils.execute(cmd, config.env_script, env, args, config.cwd, config.executor, callback)
+  return utils.execute(cmd, config.env_script, env, args, cwd, config.executor, callback)
 end
 
 function cmake.quick_build(opt, callback)


### PR DESCRIPTION
config:build_directory_path() is relative to nvim's cwd, not the cwd as given in the config, so cmake --build will fail if config.cwd is a subdirectory of nvim's cwd. On the other hand, when using build presets CMake's cwd *must* be the directory where the preset files are. Fix this by only using config.cwd when building with presets.