### PR TITLE
fix: Change defaults to match README

### DIFF
--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -54,7 +54,9 @@ local const = {
             "terminal",
           },
         }, -- options to pass into the `overseer.new_task` command
-        on_new_task = function(task) end, -- a function that gets overseer.Task when it is created, before calling `task:start`
+        on_new_task = function(task)
+          require("overseer").open({ enter = false, direction = "right" })
+        end, -- a function that gets overseer.Task when it is created, before calling `task:start`
       },
       terminal = {
         name = "Executor Terminal",


### PR DESCRIPTION
cb7dc21a6da58f improved the defaults for overseer, but omitted to set actually set on_new_task to the value stated in the README.