### PR TITLE
Fix CMakeRun error in windows, Caused by slash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ require("cmake-tools").setup {
       terminal = {
         name = "Main Terminal",
         prefix_name = "[CMakeTools]: ", -- This must be included and must be unique, otherwise the terminals will not work. Do not use a simple spacebar " ", or any generic name
+        -- If you are using windows for neovim(not wsl), It's better to not use '[ ]', because it will appeal an error because the bug of neovim
         split_direction = "horizontal", -- "horizontal", "vertical"
         split_size = 11,
 
@@ -140,6 +141,7 @@ require("cmake-tools").setup {
       terminal = {
         name = "Main Terminal",
         prefix_name = "[CMakeTools]: ", -- This must be included and must be unique, otherwise the terminals will not work. Do not use a simple spacebar " ", or any generic name
+        -- If you are using windows for neovim(not wsl), It's better to not use '[ ]', because it will appeal an error because the bug of neovim
         split_direction = "horizontal", -- "horizontal", "vertical"
         split_size = 11,
 
@@ -168,11 +170,11 @@ require("cmake-tools").setup {
 
 Generally, the default is enough.
 
-*And attention, when you firstly enter a new project, a session file for this project will be created, and `cmake_generate_options`, `cmake_build_options`, `cmake_build_directory` in your configuration will be used to initialize some fields of it. Then, if you reopen this project, it will reuse this session file to initialize these fields, or, you can think this project has its own settings, so if you change the values in global configuration, it will not reflect on these projects, you should refresh these fields by your own. Also see [session docs](./docs/sessions.md) and issue [#162](https://github.com/Civitasv/cmake-tools.nvim/issues/162).*
+_And attention, when you firstly enter a new project, a session file for this project will be created, and `cmake_generate_options`, `cmake_build_options`, `cmake_build_directory` in your configuration will be used to initialize some fields of it. Then, if you reopen this project, it will reuse this session file to initialize these fields, or, you can think this project has its own settings, so if you change the values in global configuration, it will not reflect on these projects, you should refresh these fields by your own. Also see [session docs](./docs/sessions.md) and issue [#162](https://github.com/Civitasv/cmake-tools.nvim/issues/162)._
 
 ## :magic_wand: Docs
 
-*Our plugin will automatically create a buffer named \*cmake-tools\*, all commands executed by this plugin will be dumped in this buffer, so when something goes wrong, you can know excatly what happend.*
+_Our plugin will automatically create a buffer named \*cmake-tools\*, all commands executed by this plugin will be dumped in this buffer, so when something goes wrong, you can know excatly what happend._
 
 1. [basic usage](./docs/basic_usage.md)
 2. [settings](./docs/settings.md)

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -572,7 +572,12 @@ function _terminal.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output
   local function prepare_run(cmd, env, args, cwd)
     -- Escape all special pattern characters
     local escapedCwd = cwd:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
-    cmd = cmd:gsub(escapedCwd, osys.iswin32 and ".\\" or "./")
+    if osys.iswin32 then
+      cmd = cmd:gsub(escapedCwd, ".\\")
+      cmd = cmd:gsub("/", "\\")
+    else
+      cmd = cmd:gsub(escapedCwd, "./")
+    end
     cwd = utils.transform_path(cwd)
     local envTbl = {}
     local fmtStr = osys.iswin32 and "set %s=%s" or "%s=%s"

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -570,8 +570,6 @@ end
 ---@param on_output any !unused here added for the sake of unification
 function _terminal.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output)
   local function prepare_run(cmd, env, args, cwd)
-    vim.notify(string.format("Original cmd: %s", cmd), vim.log.levels.WARN)
-    vim.notify(string.format("Original cwd: %s", cwd), vim.log.levels.WARN)
     local escapedCwd = cwd:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
 
     if osys.iswin32 then

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -570,6 +570,8 @@ end
 ---@param on_output any !unused here added for the sake of unification
 function _terminal.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output)
   local function prepare_run(cmd, env, args, cwd)
+    vim.notify(string.format("Original cmd: %s", cmd), vim.log.levels.DEBUG)
+    vim.notify(string.format("Original cwd: %s", cwd), vim.log.levels.DEBUG)
     local escapedCwd = cwd:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
 
     if osys.iswin32 then

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -570,8 +570,8 @@ end
 ---@param on_output any !unused here added for the sake of unification
 function _terminal.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output)
   local function prepare_run(cmd, env, args, cwd)
-    vim.notify(string.format("Original cmd: %s", cmd), vim.log.levels.DEBUG)
-    vim.notify(string.format("Original cwd: %s", cwd), vim.log.levels.DEBUG)
+    vim.notify(string.format("Original cmd: %s", cmd), vim.log.levels.WARN)
+    vim.notify(string.format("Original cwd: %s", cwd), vim.log.levels.WARN)
     local escapedCwd = cwd:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
 
     if osys.iswin32 then


### PR DESCRIPTION
Fix the path slash error on windows when use CMakeRun.

