### PR TITLE
fix(windows): Fix powershell legacy and operator `&&`

### DIFF
--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -532,6 +532,7 @@ local get_command_handling_on_exit = function()
 
   local exit_op = "$?"
   local escape_rm = " \\rm -f "
+  local and_op = " &&"
 
   if is_fish_shell() then
     exit_op = "$status"
@@ -540,12 +541,13 @@ local get_command_handling_on_exit = function()
 
   if osys.iswin32 then
     exit_op = is_power_shell() and "$LASTEXITCODE" or "%errorlevel%"
+    and_op = is_power_shell() and " -and" or " &&"
     escape_rm = is_power_shell() and " Remove-Item " or " del /Q "
     exit_code_file_path = exit_code_file_path:gsub("/", "\\")
     lock_file_path = lock_file_path:gsub("/", "\\")
   end
 
-  return "echo " .. exit_op .. " > " .. exit_code_file_path .. " &&" .. escape_rm .. lock_file_path
+  return "echo " .. exit_op .. " > " .. exit_code_file_path .. and_op .. escape_rm .. lock_file_path
 end
 
 ---tries to read the number stored in get_last_exit_code_file_path() file


### PR DESCRIPTION
The windows powershell legacy ( version 5.1 that come default with windows) does not have the `&&` operator which cause `CMakeRun` command error:

```
C:\Users\Michael\projects\cpp\DSA> cmd /C "cd C:\Users\Michael\projects\cpp\DSA\./build\Pro\Bacteria\ && .\Bacteria.exe"; echo $LASTEXITCODE > C:\Users\Michael\AppData\Local\nvim-data
\cmake-tools-tmp\exit_code && Remove-Item C:\Users\Michael\AppData\Local\nvim-data\cmake-tools-tmp\.lock 
At line:1 char:176
+ ... \Michael\AppData\Local\nvim-data\cmake-tools-tmp\exit_code && Remove- ...
+                                                                ~~
The token '&&' is not a valid statement separator in this version.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : InvalidEndOfLine
```

So I suggest using the `-and` operator since both the legacy and the newer version of powershell support this.