### PR TITLE
Add support for CMAKE_BUILD_TYPE presets using "type"/"value" form.

### DIFF
--- a/lua/cmake-tools/preset.lua
+++ b/lua/cmake-tools/preset.lua
@@ -4,8 +4,8 @@ local osys = require("cmake-tools.osys")
 local Preset = {}
 
 local function expandMacro(self, str)
-  if type(str) == "table" and str["value"] ~= nil then
-    str = str["value"]
+  if type(str) == "table" and str.value ~= nil then
+    str = str.value
   end
 
   if type(str) ~= "string" then

--- a/lua/cmake-tools/preset.lua
+++ b/lua/cmake-tools/preset.lua
@@ -267,7 +267,13 @@ function Preset:new(cwd, obj, get_preset)
 end
 
 function Preset:get_build_type()
-  return self.cacheVariables and self.cacheVariables.CMAKE_BUILD_TYPE or "Debug"
+  if self.cacheVariables and self.cacheVariables.CMAKE_BUILD_TYPE then
+    if type(self.cacheVariables.CMAKE_BUILD_TYPE) == "table" then
+      return self.cacheVariables.CMAKE_BUILD_TYPE["value"]
+    end
+    return self.cacheVariables.CMAKE_BUILD_TYPE
+  end
+  return "Debug"
 end
 
 return Preset

--- a/lua/cmake-tools/preset.lua
+++ b/lua/cmake-tools/preset.lua
@@ -5,7 +5,7 @@ local Preset = {}
 
 local function expandMacro(self, str)
   if type(str) == "table" and str["value"] ~= nil then
-    return str["value"]
+    str = str["value"]
   end
 
   if type(str) ~= "string" then

--- a/lua/cmake-tools/preset.lua
+++ b/lua/cmake-tools/preset.lua
@@ -4,6 +4,10 @@ local osys = require("cmake-tools.osys")
 local Preset = {}
 
 local function expandMacro(self, str)
+  if type(str) == "table" and str["value"] ~= nil then
+    return str["value"]
+  end
+
   if type(str) ~= "string" then
     return str
   end
@@ -267,13 +271,7 @@ function Preset:new(cwd, obj, get_preset)
 end
 
 function Preset:get_build_type()
-  if self.cacheVariables and self.cacheVariables.CMAKE_BUILD_TYPE then
-    if type(self.cacheVariables.CMAKE_BUILD_TYPE) == "table" then
-      return self.cacheVariables.CMAKE_BUILD_TYPE["value"]
-    end
-    return self.cacheVariables.CMAKE_BUILD_TYPE
-  end
-  return "Debug"
+  return self.cacheVariables and self.cacheVariables.CMAKE_BUILD_TYPE or "Debug"
 end
 
 return Preset


### PR DESCRIPTION
With the current implementation, if CMakePresets.json sets CMAKE_BUILD_TYPE as a JSON object with a "type" and "value", then it causes the build/configuration fail -- example below.

```json
"CMAKE_BUILD_TYPE": {
  "type": "STRING",
  "value": "Debug"
}
```

This fix looks for a CMAKE_BUILD_TYPE with a "table" type and extracts the "value" element, otherwise it falls back to the original behavior.