### PR TITLE
fix: Fix error message when Overseer is running a job

### DIFF
--- a/lua/cmake-tools/overseer.lua
+++ b/lua/cmake-tools/overseer.lua
@@ -50,9 +50,9 @@ end
 function _overseer.has_active_job(opts)
   if _overseer.job ~= nil and _overseer.job:is_running() then
     log.error(
-      "A CMake task is already running: "
-        .. _overseer.job.command
-        .. " Stop it before trying to run a new CMake task."
+      "A CMake task is already running: `"
+        .. (_overseer.job.name or _overseer.job.cmd)
+        .. "` Stop it before trying to run a new CMake task."
     )
     return true
   end


### PR DESCRIPTION
`command` is not a field on `overseer.Task` leading to this error
originating from check_active_job_and_notify():

    "Error executing Lua callback: .../nvim/lazy/cmake-tools.nvim/lua/cmake-tools/overseer.lua:55: attempt to concatenate field 'command' (a nil value)"

But `cmd` is a valid field. Though if the user gives the task a custom
name then that's probably what they want to see.
