### PR TITLE
Make compile_commands.json symlinking "silent"

### DIFF
--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -86,7 +86,7 @@ end
 function utils.softlink(src, target)
   if utils.file_exists(src) and not utils.file_exists(target) then
     -- if we don't always use terminal
-    local cmd = "exec "
+    local cmd = "silent exec "
       .. "'!cmake -E create_symlink "
       .. utils.transform_path(src)
       .. " "


### PR DESCRIPTION
Prior to this change, the user is forced to acknowledge the creation of the symlink.

Now, the symlink happens "silently" in the background without extra user steps.