### PR TITLE
fix: Indexing a nil value when no target launch settings are configured

### DIFF
--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -525,7 +525,9 @@ function cmake.run(opt, callback)
 
       local launch_path = cmake.get_launch_path(opt.target)
       local env = environment.get_run_environment(config, opt.target)
-      local _args = opt.args and opt.args or config.target_settings[opt.target].args
+      local _args = opt.args and opt.args
+        or utils.get_nested(config, "target_settings", opt.target, "args")
+        or {}
       local cmd = target_path
       utils.run(cmd, config.env_script, env, _args, launch_path, config.runner, callback)
     end)
@@ -1573,7 +1575,9 @@ function cmake.register_dap_function()
             name = opt.target,
             program = result.data,
             cwd = cmake.get_launch_path(opt.target),
-            args = opt.args and opt.args or config.target_settings[opt.target].args,
+            args = opt.args and opt.args
+              or utils.get_nested(config, "target_settings", opt.target, "args")
+              or {},
             env = env,
             initCommands = initCmds,
           }

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -269,4 +269,15 @@ function utils.execute(cmd, env_script, env, args, cwd, executor, callback)
     end, notify_update_line(ntfy))
 end
 
+function utils.get_nested(tbl, ...)
+  local value = tbl
+  for _, key in ipairs({ ... }) do
+    value = value and value[key]
+    if value == nil then
+      return nil
+    end
+  end
+  return value
+end
+
 return utils


### PR DESCRIPTION
When running a specific target (e.g. `CMakeQuickRun`) there might not be a `target_settings` config available. Previously the `target_settings` of that target were always accessed assuming it was there.
Now each access is checked and an empty table is used as a fallback.

Feel free to make any changes or suggestions!