### PR TITLE
fix: include included presets as well

### DIFF
--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -50,6 +50,14 @@ local function decode(file)
     end
 
     local fdata = vim.fn.json_decode(f_read_data)
+    local fincludes = fdata["include"] and fdata["include"] or {}
+    for _, inc in ipairs(fincludes) do
+        local f_include_path = Path.new(inc)
+        if not f_include_path:is_absolute() then
+            f_include_path = (f_path:parent() / inc):normalize()
+        end
+        includes[#includes + 1] = f_include_path
+    end
     local thisFilePresetKeys = vim.tbl_filter(function(key)
       if string.find(key, "Presets") then
         return true


### PR DESCRIPTION
If a preset-file is included, its includes were not respected.
This patch adjusts this.

One issue is, that presets become duplicated if e.g. a base-preset is included from multiple preset files. I did not find the time for a simple solution. If all preset paths were converted to absolute paths in `includes`, the preset-file could be appended only if it is not present yet.