### PR TITLE
Exposed config.cwd for the user

### DIFF
--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -29,7 +29,7 @@ local Config = {
   executor = nil,
   runner = nil,
   env_script = " ",
-  cwd = vim.loop.cwd(),
+  cwd = vim.fn.getcwd(),
 }
 
 function Config:new(const)

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -29,7 +29,7 @@ local Config = {
   executor = nil,
   runner = nil,
   env_script = " ",
-  cwd = vim.fn.getcwd(),
+  cwd = nil,
 }
 
 function Config:new(const)

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -1,5 +1,6 @@
 local osys = require("cmake-tools.osys")
 local const = {
+  cwd = vim.fn.getcwd(),
   cmake_command = "cmake", -- this is used to specify cmake command path
   ctest_command = "ctest", -- this is used to specify ctest command path
   cmake_use_preset = true, -- when `false`, this is used to define if the `--preset` option should be use on cmake commands

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1297,7 +1297,7 @@ function cmake.compile_commands_from_soft_link()
   end
 
   local source = config:build_directory_path() .. "/compile_commands.json"
-  local destination = vim.loop.cwd() .. "/compile_commands.json"
+  local destination = vim.fn.getcwd() .. "/compile_commands.json"
   utils.softlink(source, destination)
 end
 
@@ -1307,7 +1307,7 @@ function cmake.compile_commands_from_lsp()
   end
 
   local buf = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_active_clients({ name = const.lsp_type })
+  local clients = vim.lsp.get_clients({ name = const.lsp_type })
   for _, client in ipairs(clients) do
     local lspbufs = vim.lsp.get_buffers_by_client_id(client.id)
     for _, bufid in ipairs(lspbufs) do
@@ -1455,7 +1455,7 @@ function cmake.create_regenerate_on_save_autocmd()
         local buf = vim.api.nvim_get_current_buf()
         -- Check if buffer is actually modified, and only if it is modified,
         -- execute the :CMakeGenerate, otherwise return. This is to avoid unnecessary regenerattion
-        if vim.api.nvim_buf_get_option(buf, "modified") then
+        if vim.api.nvim_get_option_value("modified", { buf = buf }) then
           vim.api.nvim_create_autocmd("BufWritePost", {
             group = group,
             once = true,

--- a/lua/cmake-tools/quickfix.lua
+++ b/lua/cmake-tools/quickfix.lua
@@ -118,7 +118,7 @@ function _quickfix.check_scroll()
     return cursor_pos[1] == line_count - 1
   end
 
-  local buffer_type = vim.api.nvim_buf_get_option(0, "buftype")
+  local buffer_type = vim.api.nvim_get_option_value("buftype", { buf = 0 })
 
   if buffer_type == "quickfix" then
     return is_cursor_at_last_line()

--- a/lua/cmake-tools/quickstart/init.lua
+++ b/lua/cmake-tools/quickstart/init.lua
@@ -1,5 +1,6 @@
 local cmake = require("cmake-tools")
 local etlua = require("cmake-tools.quickstart.etlua")
+local config = require("cmake-tools.config")
 local locals = {
   project_version = "0.0.1",
   project_name = "project",
@@ -32,7 +33,7 @@ local generate_cmakelists_file = function()
     return
   end
   local template = etlua.compile(file:read("*a"))
-  local main_file_path = vim.fn.getcwd() .. "/CMakeLists.txt"
+  local main_file_path = config.cwd .. "/CMakeLists.txt"
   file = io.open(main_file_path, "w")
   if not file then
     error("could not create the file: " .. main_file_path)
@@ -58,7 +59,7 @@ local generate_main_file = function()
   if locals.type == "lib" then
     main_file_name = locals.project_name
   end
-  local main_file_path = vim.fn.getcwd() .. "/" .. main_file_name .. "." .. locals.language
+  local main_file_path = config.cwd .. "/" .. main_file_name .. "." .. locals.language
 
   file = io.open(main_file_path, "w")
   if not file then

--- a/lua/cmake-tools/quickstart/init.lua
+++ b/lua/cmake-tools/quickstart/init.lua
@@ -32,7 +32,7 @@ local generate_cmakelists_file = function()
     return
   end
   local template = etlua.compile(file:read("*a"))
-  local main_file_path = vim.loop.cwd() .. "/CMakeLists.txt"
+  local main_file_path = vim.fn.getcwd() .. "/CMakeLists.txt"
   file = io.open(main_file_path, "w")
   if not file then
     error("could not create the file: " .. main_file_path)
@@ -58,7 +58,7 @@ local generate_main_file = function()
   if locals.type == "lib" then
     main_file_name = locals.project_name
   end
-  local main_file_path = vim.loop.cwd() .. "/" .. main_file_name .. "." .. locals.language
+  local main_file_path = vim.fn.getcwd() .. "/" .. main_file_name .. "." .. locals.language
 
   file = io.open(main_file_path, "w")
   if not file then

--- a/lua/cmake-tools/scratch.lua
+++ b/lua/cmake-tools/scratch.lua
@@ -4,22 +4,31 @@ local scratch = {
 }
 
 function scratch.create(executor, runner)
-  if scratch.buffer ~= nil then
+  if scratch.buffer and vim.api.nvim_buf_is_valid(scratch.buffer) then
     return
   end
 
-  scratch.buffer = vim.api.nvim_create_buf(true, true) -- can be search, and is a scratch buffer
+  scratch.buffer = vim.api.nvim_create_buf(true, true)
   vim.api.nvim_buf_set_name(scratch.buffer, scratch.name)
   vim.api.nvim_buf_set_lines(scratch.buffer, 0, 0, false, {
     "THIS IS A SCRATCH BUFFER FOR cmake-tools.nvim, YOU CAN SEE WHICH COMMAND THIS PLUGIN EXECUTES HERE.",
     "EXECUTOR: " .. executor .. " RUNNER: " .. runner,
   })
-  vim.api.nvim_buf_set_option(scratch.buffer, "buflisted", false)
+
+  -- Better scratch behavior
+  vim.api.nvim_set_option_value("buflisted", false, { buf = scratch.buffer })
+  vim.api.nvim_set_option_value("buftype", "nofile", { buf = scratch.buffer })
+  vim.api.nvim_set_option_value("bufhidden", "hide", { buf = scratch.buffer })
+  vim.api.nvim_set_option_value("swapfile", false, { buf = scratch.buffer })
 end
 
 function scratch.append(cmd)
   vim.schedule(function()
-    vim.api.nvim_buf_set_lines(scratch.buffer, -1, -1, false, { cmd })
+    if scratch.buffer and vim.api.nvim_buf_is_valid(scratch.buffer) then
+      vim.api.nvim_buf_set_lines(scratch.buffer, -1, -1, false, { cmd })
+    else
+      vim.notify("[cmake-tools.nvim] scratch buffer not created yet", vim.log.levels.WARN)
+    end
   end)
 end
 

--- a/lua/cmake-tools/session.lua
+++ b/lua/cmake-tools/session.lua
@@ -24,7 +24,7 @@ local function get_cache_path()
 end
 
 local function get_current_path()
-  local current_path = vim.loop.cwd()
+  local current_path = vim.fn.getcwd()
   local clean_path = current_path:gsub("/", "")
   clean_path = clean_path:gsub("\\", "")
   clean_path = clean_path:gsub(":", "")


### PR DESCRIPTION
It really annoyed me how when opening a single cpp file it couldn't find the base CMakeLists.txt, so I did some changes:

- removed deprecated nvim commands and replaced with their new counterpart
- exposed cwd to be accessible from opts

I should mention this still **doesn't fully work**, it seems like the path gets overridden at some point and idk why. 
Also should mention this is my first time trying to maintain anything lua related lmao.
If anyone is willing to help on this I'd appreciate it a lot, I find it so disruptive that I can't just open a file and it find out where the CMakeLists.txt file is, sets up the build directory correctly, and generally doesn't cooperate when opening a file that doesn't immediately set cwd to be the root directory.