### PR TITLE
Option to pass extra arguments to ctest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ local osys = require("cmake-tools.osys")
 require("cmake-tools").setup {
   cmake_command = "cmake", -- this is used to specify cmake command path
   ctest_command = "ctest", -- this is used to specify ctest command path
+  ctest_extra_args = {}, -- this is used to specify extra args for ctest
   cmake_use_preset = true,
   cmake_regenerate_on_save = true, -- auto generate when save CMakeLists.txt
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- this will be passed when invoke `CMakeGenerate`

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -49,7 +49,7 @@ function Config:new(const)
 
   obj.executor = const.cmake_executor
   obj.runner = const.cmake_runner
-  for _,v in pairs(const.ctest_extra_args) do
+  for _, v in pairs(const.ctest_extra_args) do
     table.insert(obj.ctest.extra_args, v)
   end
   return obj

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -9,6 +9,9 @@ local Config = {
   build_directory = nil,
   query_directory = nil,
   reply_directory = nil,
+  ctest = {
+    extra_args = {},
+  },
   build_type = nil,
   variant = nil,
   build_target = nil,
@@ -46,7 +49,9 @@ function Config:new(const)
 
   obj.executor = const.cmake_executor
   obj.runner = const.cmake_runner
-
+  for _,v in pairs(const.ctest_extra_args) do
+    table.insert(obj.ctest.extra_args, v)
+  end
   return obj
 end
 

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -2,6 +2,7 @@ local osys = require("cmake-tools.osys")
 local const = {
   cmake_command = "cmake", -- this is used to specify cmake command path
   ctest_command = "ctest", -- this is used to specify ctest command path
+  ctest_extra_args = {}, -- this is used to specify extra arguments for ctest
   cmake_use_preset = true, -- when `false`, this is used to define if the `--preset` option should be use on cmake commands
   cmake_regenerate_on_save = true, -- auto generate when save CMakeLists.txt
   cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }, -- this will be passed when invoke `CMakeGenerate`

--- a/lua/cmake-tools/test/ctest.lua
+++ b/lua/cmake-tools/test/ctest.lua
@@ -37,6 +37,9 @@ function ctest.run(ctest_command, test_name, build_dir, env, config, opt)
   opt = opt or {}
 
   local args = { "--test-dir", utils.transform_path(build_dir), "-R", test_name, opt.args }
+  for _, v in pairs(config.ctest.extra_args) do
+    table.insert(args, v)
+  end
   utils.run(
     cmd,
     config.env_script,

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,0 +1,23 @@
+local const = require("cmake-tools.const")
+
+describe('Config', function()
+  local Config
+  local local_const
+
+  before_each(function()
+    package.loaded['cmake-tools.config'] = nil
+    Config = require('cmake-tools.config')
+    local_const = vim.deepcopy(const)
+  end)
+
+  it('should parse user provided ctest arguments', function()
+    local_const.ctest_extra_args = { "-j", "6" }
+    local config = Config:new(local_const)
+    assert.are_same({ "-j", "6" }, config.ctest.extra_args)
+  end)
+
+  it('should parse user ctest empty arguments', function()
+    local config = Config:new(const)
+    assert.are_same({}, config.ctest.extra_args)
+  end)
+end)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,22 +1,22 @@
 local const = require("cmake-tools.const")
 
-describe('Config', function()
+describe("Config", function()
   local Config
   local local_const
 
   before_each(function()
-    package.loaded['cmake-tools.config'] = nil
-    Config = require('cmake-tools.config')
+    package.loaded["cmake-tools.config"] = nil
+    Config = require("cmake-tools.config")
     local_const = vim.deepcopy(const)
   end)
 
-  it('should parse user provided ctest arguments', function()
+  it("should parse user provided ctest arguments", function()
     local_const.ctest_extra_args = { "-j", "6" }
     local config = Config:new(local_const)
     assert.are_same({ "-j", "6" }, config.ctest.extra_args)
   end)
 
-  it('should parse user ctest empty arguments', function()
+  it("should parse user ctest empty arguments", function()
     local config = Config:new(const)
     assert.are_same({}, config.ctest.extra_args)
   end)

--- a/tests/ctest_spec.lua
+++ b/tests/ctest_spec.lua
@@ -1,0 +1,35 @@
+local match = require('luassert.match')
+local stub = require('luassert.stub')
+local const = require('cmake-tools.const')
+local ctest = require("cmake-tools.test.ctest")
+local utils = require('cmake-tools.utils')
+
+describe("run", function()
+  local local_const
+  local Config
+  local expected
+  before_each(function()
+    package.loaded['cmake-tools.config'] = nil
+    Config = require('cmake-tools.config')
+    local_const = vim.deepcopy(const)
+    expected = { "--test-dir", "build_dir", "-R", "test_name" }
+    stub(utils, "run")
+  end)
+
+  it("takes extra args from user config", function()
+    local_const.ctest_extra_args = { "-j", "6" }
+    local config = Config:new(local_const)
+    ctest:run("test_name", "build_dir", "env", config, {})
+    table.insert(expected, "-j")
+    table.insert(expected, "6")
+    assert.stub(utils.run).was.called_with(match._, match._, match._, expected,
+      match._, match._, match._, match._)
+  end)
+
+  it("ignores extra args if not provided", function()
+    local config = Config:new(const)
+    ctest:run("test_name", "build_dir", "env", config, {})
+    assert.stub(utils.run).was.called_with(match._, match._, match._, expected,
+      match._, match._, match._, match._)
+  end)
+end)

--- a/tests/ctest_spec.lua
+++ b/tests/ctest_spec.lua
@@ -1,16 +1,16 @@
-local match = require('luassert.match')
-local stub = require('luassert.stub')
-local const = require('cmake-tools.const')
+local match = require("luassert.match")
+local stub = require("luassert.stub")
+local const = require("cmake-tools.const")
 local ctest = require("cmake-tools.test.ctest")
-local utils = require('cmake-tools.utils')
+local utils = require("cmake-tools.utils")
 
 describe("run", function()
   local local_const
   local Config
   local expected
   before_each(function()
-    package.loaded['cmake-tools.config'] = nil
-    Config = require('cmake-tools.config')
+    package.loaded["cmake-tools.config"] = nil
+    Config = require("cmake-tools.config")
     local_const = vim.deepcopy(const)
     expected = { "--test-dir", "build_dir", "-R", "test_name" }
     stub(utils, "run")
@@ -22,14 +22,16 @@ describe("run", function()
     ctest:run("test_name", "build_dir", "env", config, {})
     table.insert(expected, "-j")
     table.insert(expected, "6")
-    assert.stub(utils.run).was.called_with(match._, match._, match._, expected,
-      match._, match._, match._, match._)
+    assert
+      .stub(utils.run).was
+      .called_with(match._, match._, match._, expected, match._, match._, match._, match._)
   end)
 
   it("ignores extra args if not provided", function()
     local config = Config:new(const)
     ctest:run("test_name", "build_dir", "env", config, {})
-    assert.stub(utils.run).was.called_with(match._, match._, match._, expected,
-      match._, match._, match._, match._)
+    assert
+      .stub(utils.run).was
+      .called_with(match._, match._, match._, expected, match._, match._, match._, match._)
   end)
 end)


### PR DESCRIPTION
This patch enables the plugin to pass extra args to ctest when running tests.

Resolves: #296 