### PR TITLE
feat: supports copy compile commands and specify target directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,14 @@ require("cmake-tools").setup {
     end
     return "out/${variant:buildType}"
   end, -- this is used to specify generate directory for cmake, allows macro expansion, can be a string or a function returning the string, relative to cwd.
-  cmake_soft_link_compile_commands = true, -- this will automatically make a soft link from compile commands file to project root dir
-  cmake_compile_commands_from_lsp = false, -- this will automatically set compile commands file location using lsp, to use it, please set `cmake_soft_link_compile_commands` to false
+  cmake_compile_commands_options = {
+    action = "soft_link", -- available options: soft_link, copy, lsp, none
+                          -- soft_link: this will automatically make a soft link from compile commands file to target
+                          -- copy:      this will automatically copy compile commands file to target
+                          -- lsp:       this will automatically set compile commands file location using lsp
+                          -- none:      this will make this option ignored
+    target = vim.loop.cwd() -- path to directory, this is used only if action == "soft_link" or action == "copy"
+  },
   cmake_kits_path = nil, -- this is used to specify global cmake kits path, see CMakeKits for detailed usage
   cmake_variants_message = {
     short = { show = true }, -- whether to show short message

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -2,11 +2,12 @@
 
 ## Automatically set your compile_commands.json
 
-There are two ways:
+There are three ways:
 
-- Use softlink: firstly, you should set `cmake_soft_link_compile_commands` to true, then, this plugin will automatically make a softlink to compile_commands.json after generation.
+- Use softlink: Firstly, you should set `cmake_compile_commands_options.action` to `soft_link`, then, this plugin will automatically make a softlink to compile_commands.json after generation.
+- Copy compile_commands.json: Set `cmake_compile_commands_options.action` to `copy` then the plugin will automatically copy compile_commands.json to directory specified by `cmake_compile_commands_options.target` after generation.
 - Use lsp: If you're using clangd or ccls configured through [lspconfig](https://github.com/neovim/nvim-lspconfig) you can
-  set your compilation database directory to your active build directory by calling a hook in your on_new_config callback provided by lspconfig.
+  set your compilation database directory to your active build directory by calling a hook in your on_new_config callback provided by lspconfig. You need to set `cmake_compile_commands_options.action` to `none` to disable softlink and copy.
 
 ```lua
 require('lspconfig').clangd.setup{

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -13,8 +13,14 @@ local const = {
     end
     return "out/${variant:buildType}"
   end, -- this is used to specify generate directory for cmake
-  cmake_soft_link_compile_commands = true, -- this will automatically make a soft link from compile commands file to project root dir
-  cmake_compile_commands_from_lsp = false, -- this will automatically set compile commands file location using lsp, to use it, please set `cmake_soft_link_compile_commands` to false
+  cmake_compile_commands_options = {
+    action = "soft_link", -- available options: soft_link, copy, lsp, none
+                          -- soft_link: this will automatically make a soft link from compile commands file to target
+                          -- copy:      this will automatically copy compile commands file to target
+                          -- lsp:       this will automatically set compile commands file location using lsp
+                          -- none:      this will make this option ignored
+    target = vim.loop.cwd() -- path to directory, this is used only if action == "soft_link" or action == "copy"
+  },
   cmake_kits_path = nil, -- this is used to specify global cmake kits path, see CMakeKits for detailed usage
   cmake_variants_message = {
     short = { show = true }, -- whether to show short message

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1284,11 +1284,24 @@ end
 --[[ end ]]
 
 function cmake.configure_compile_commands()
-  if const.cmake_soft_link_compile_commands then
+  local action = const.cmake_compile_commands_options.action
+  if action == "soft_link" then
     cmake.compile_commands_from_soft_link()
-  elseif const.cmake_compile_commands_from_lsp then
+  elseif action == "copy" then
+    cmake.copy_compile_commands()
+  elseif action == "lsp" then
     cmake.compile_commands_from_lsp()
   end
+end
+
+function cmake.copy_compile_commands()
+  if not config:has_build_directory() then
+    return
+  end
+
+  local source = config:build_directory_path() .. "/compile_commands.json"
+  local destination = const.cmake_compile_commands_options.target .. "/compile_commands.json"
+  utils.copyfile(source, destination)
 end
 
 function cmake.compile_commands_from_soft_link()
@@ -1297,7 +1310,7 @@ function cmake.compile_commands_from_soft_link()
   end
 
   local source = config:build_directory_path() .. "/compile_commands.json"
-  local destination = vim.loop.cwd() .. "/compile_commands.json"
+  local destination = const.cmake_compile_commands_options.target .. "/compile_commands.json"
   utils.softlink(source, destination)
 end
 

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -83,6 +83,19 @@ function utils.deepcopy(orig, copies)
   return copy
 end
 
+function utils.copyfile(src, target)
+  if utils.file_exists(src) then
+    -- if we don't always use terminal
+    local cmd = "exec "
+      .. "'!cmake -E copy "
+      .. utils.transform_path(src)
+      .. " "
+      .. utils.transform_path(target)
+      .. "'"
+    vim.cmd(cmd)
+  end
+end
+
 function utils.softlink(src, target)
   if utils.file_exists(src) and not utils.file_exists(target) then
     -- if we don't always use terminal


### PR DESCRIPTION
Replaced `cmake_soft_link_compile_commands` and `cmake_compile_commands_from_lsp` with `cmake_compile_commands_options`, where you can specify action and target path:
```lua
cmake_compile_commands_options = {
  action = "soft_link", -- available options: soft_link, copy, lsp, none
                        -- soft_link: this will automatically make a soft link from compile commands file to target
                        -- copy:      this will automatically copy compile commands file to target
                        -- lsp:       this will automatically set compile commands file location using lsp
                        -- none:      this will make this option ignored
  target = vim.loop.cwd() -- path to directory, this is used only if action == "soft_link" or action == "copy"
},
```
With `action = "soft_link"`, the behavior is the same as
```lua
cmake_soft_link_compile_commands = true
```
With `action = "lsp"`, the behavior is the same as
```lua
cmake_soft_link_compile_commands = false,
cmake_compile_commands_from_lsp = true
```
With `action = "none"`, the behavior is the same as
```lua
cmake_soft_link_compile_commands = false,
cmake_compile_commands_from_lsp = false
```
Default behavior remains unchanged. The `copy` action is my personal preference, and is also requested by #243 .

`target` is path to directory where the created symlink file or copied compile_commands.json is stored. Previously it is hardcoded to `vim.loop.cwd()`, now it's configurable.

I'm really bad at naming things, so if you don't like the naming or any other thing, feel free to give suggestions or just close PR.