### PR TITLE
fix: only append when scratch.buffer is not nil

### DIFF
--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -205,9 +205,11 @@ function utils.run(cmd, env_script, env, args, cwd, runner, callback)
 
   ntfy:notify(cmd, "info")
 
-  local _mes =
-    { "[RUN]:", cmd, table.concat(args, " "), "<ENV>", table.concat(env, " "), "{CWD}", cwd }
-  scratch.append(table.concat(_mes, " "))
+  if scratch.buffer ~= nil then
+    local _mes =
+      { "[RUN]:", cmd, table.concat(args, " "), "<ENV>", table.concat(env, " "), "{CWD}", cwd }
+    scratch.append(table.concat(_mes, " "))
+  end
 
   utils.get_runner(runner.name).run(cmd, env_script, env, args, cwd, runner.opts, function(code)
     local msg = "Exited with code " .. code
@@ -244,9 +246,11 @@ function utils.execute(cmd, env_script, env, args, cwd, executor, callback)
   local ntfy = notification:new("executor")
   ntfy:notify(cmd, "info")
 
-  local _mes =
-    { "[EXECUTE]:", cmd, table.concat(args, " "), "<ENV>", table.concat(env, " "), "{CWD}", cwd }
-  scratch.append(table.concat(_mes, " "))
+  if scratch.buffer ~= nil then
+    local _mes =
+      { "[EXECUTE]:", cmd, table.concat(args, " "), "<ENV>", table.concat(env, " "), "{CWD}", cwd }
+    scratch.append(table.concat(_mes, " "))
+  end
 
   utils
     .get_executor(executor.name)


### PR DESCRIPTION
The new feature cmake_use_scratch_buffer lets user can decide whether to use the scratch buffer. @Civitasv ensures that the scratch is created only when cmake_use_scratch_buffer is true. But no matter whether this scratch buffer is created, scratch.append would be called when new operation is performed.
Thus, I add a check to ensure that scratch.append would be called only when scratch buffer exists.