### PR TITLE
fix: CMakeRun defaults to Debug configuration regardless of build type.

### DIFF
--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -210,7 +210,12 @@ function Config:get_codemodel_targets()
   end
   local codemodel = Path:new(found_files[1])
   local codemodel_json = vim.json.decode(codemodel:read())
-  return Result:new(Types.SUCCESS, codemodel_json["configurations"][1]["targets"], "find it")
+  for _, config in ipairs(codemodel_json["configurations"]) do
+    if config["name"] == self.build_type then
+      return Result:new(Types.SUCCESS, config["targets"], "find it")
+    end
+  end
+  return Result:new(Types.CANNOT_FIND_CODEMODEL_FILE, nil, "Unable to find codemodel file")
 end
 
 function Config:get_code_model_target_info(codemodel_target)


### PR DESCRIPTION
When executing a :CMakeRun with the build type of "Release", the target is attempted to be executed from the nonexistent "\Release\Debug\" directory.

```
C:\Users\uttervitriol\source\repos\learn_cmake>cmd /C "cd C:\Users\uttervitriol\source\repos\learn_cmake\out\Release\Debug\ && .\DoThing.exe
"& echo %errorlevel% > C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\exit_code && del /Q C:\Users\uttervitriol\AppData\Local
\nvim-data\cmake-tools-tmp\.lock
The system cannot find the path specified.
```

After looking into it, it seems that the function Config:get_codemodel_targets() contains the bug producing this error.

The file (path_to_cmake)/out/(Release/Debug/etc)/.cmake/api/v1/replycodmodel.....json contains a key "configurations" whose value is an array of configurations for different build types (Release, Debug, etc).

Inside of Config:get_codemodel_targets() is this line:
```
return Result:new(Types.SUCCESS, codemodel_json["configurations"][1]["targets"], "find it")
```
```codemodel_json["configurations"][1]``` This simply grabs the first configuration in the array regardless of the build type (in my case it seems to always be Debug).

I replaced the above line of code with the snippet below:
```
  for _, config in ipairs(codemodel_json["configurations"]) do
    if config["name"] == self.build_type then
      return Result:new(Types.SUCCESS, config["targets"], "find it")
    end
  end
  return Result:new(Types.CANNOT_FIND_CODEMODEL_FILE, nil, "Unable to find codemodel file")
```

This simply loops through the array of configurations, checking its name against the currently selected build type.
I'm not sure if it's possible for the current build type to not be in the codemodel file, so I added a error at the end.

After changes:
```
C:\Users\uttervitriol\source\repos\learn_cmake>cmd /C "cd C:\Users\uttervitriol\source\repos\learn_cmake\out\Release\Release\ && .\DoThing.exe"& echo %errorlevel% > C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\exit_code && del /Q C:\Users\uttervitriol\
AppData\Local\nvim-data\cmake-tools-tmp\.lock
Why hello there
```

main.cpp
```
#include <cstdio>
int
main ()
{
    printf("Why hello there\n");
}
```
