### PR TITLE
fix(notification): nvim_win_is_valid does not accepts nil

### DIFF
--- a/lua/cmake-tools/notification.lua
+++ b/lua/cmake-tools/notification.lua
@@ -88,7 +88,7 @@ function Notification:notify(msg, level, opts)
 
   -- We have to check for a valid window here as it seems notify invokes the on_close callback async.
   -- Hence checking for self.closed would not work as it gets set too late
-  if vim.api.nvim_win_is_valid(self.win) and self.width then
+  if self.win and vim.api.nvim_win_is_valid(self.win) and self.width then
     -- update the notification width when the message was updated
     local timeDigits = 8
     local headlineLength = (self.opts.icon and (#self.opts.icon + 1) or 0)


### PR DESCRIPTION
if the window has not yet been opened, the winID is not set. Passing a nil value to nvim_win_is_valid returns an error instead of false