### PR TITLE
Fix build presets with multiple targets

### DIFF
--- a/lua/cmake-tools/build_preset.lua
+++ b/lua/cmake-tools/build_preset.lua
@@ -14,14 +14,14 @@ end
 
 function BuildPreset:get_build_target()
   if self.targets == nil then
-    return ""
+    return nil
   end
   if type(self.targets) == "string" then
+    return { self.targets }
+  elseif type(self.targets) == "table" then
     return self.targets
-  elseif type(self.targets == "table") then
-    return table.concat(self.targets, " ")
   end
-  return ""
+  return nil
 end
 
 function BuildPreset:get_build_type()

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -560,7 +560,7 @@ function Config:update_build_target()
     return
   end
   local build_target = build_preset:get_build_target()
-  if build_target ~= "" then
+  if build_target ~= nil then
     self.build_target = build_target
   end
 end

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -400,7 +400,7 @@ function cmake.build(opt, callback)
     vim.list_extend(args, { "--target", opt.target })
     vim.list_extend(args, fargs)
   elseif config.build_target ~= nil then
-    vim.list_extend(args, { "--target", config.build_target })
+    vim.list_extend(args, { "--target", unpack(config.build_target) })
     vim.list_extend(args, fargs)
   end
 
@@ -947,7 +947,7 @@ function cmake.select_build_target(regenerate, callback)
         callback(Result:new_error(Types.NOT_SELECT_BUILD_TARGET, "No target selected: cancelled"))
         return
       end
-      config.build_target = targets[idx]
+      config.build_target = { targets[idx] }
       callback(Result:new(Types.SUCCESS, config.build_target, nil))
     end)
   )


### PR DESCRIPTION
If a build preset from CMakePresets.json contained multiple targets, `BuildPreset:get_build_target` would concatenate target names into a single string which would be used as a single command line argument. The build system, such as Ninja, would then complain that the specified target is unknown.

This change modifies `BuildPreset:get_build_target` to return a table of targets instead, which is then unpacked after CMake's `--target` flag. That way, each target is a separate command line argument and the build system executes a proper multi-target build.