### PR TITLE
Fix: allow build with no selected build preset

### DIFF
--- a/lua/cmake-tools/build_preset.lua
+++ b/lua/cmake-tools/build_preset.lua
@@ -3,6 +3,18 @@ local osys = require("cmake-tools.osys")
 
 local BuildPreset = {}
 
+-- 'None' instance for when no build preset should be used.
+BuildPreset.None = {
+  is_none = true,
+  get_build_target = function()
+    return ""
+  end,
+  get_build_type = function()
+    return nil
+  end,
+}
+setmetatable(BuildPreset.None, { __index = BuildPreset })
+
 function BuildPreset:new(cwd, obj)
   local instance = setmetatable(obj or {}, { __index = self })
   instance.__index = self
@@ -18,7 +30,7 @@ function BuildPreset:get_build_target()
   end
   if type(self.targets) == "string" then
     return self.targets
-  elseif type(self.targets == "table") then
+  elseif type(self.targets) == "table" then
     return table.concat(self.targets, " ")
   end
   return ""

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -128,7 +128,7 @@ function cmake.generate(opt, callback)
       -- try to determine the confiure preset based on the build preset
       if config.build_preset then
         local build_preset = presets:get_build_preset(config.build_preset)
-        if build_preset then
+        if build_preset and not build_preset.is_none then
           local preset =
             presets:get_configure_preset(build_preset.configurePreset, { include_hidden = true })
           if preset then
@@ -387,7 +387,7 @@ function cmake.build(opt, callback)
 
   local args
 
-  if presets_exists and config.build_preset then
+  if presets_exists and config.build_preset and not config.build_preset.is_none then
     args = { "--build", "--preset", config.build_preset } -- preset don't need define build dir.
   else
     args = {
@@ -869,10 +869,8 @@ function cmake.select_build_preset(callback)
       { prompt = "Select cmake build presets", format_item = format_preset_name },
       vim.schedule_wrap(function(choice)
         if not choice or choice == "None" then
-          if choice == "None" then
-            config.build_preset = nil
-          end
-          callback(Result:new_error(Types.NOT_SELECT_PRESET, "No build preset selected"))
+          config.build_preset = Presets:createEmptyBuildPreset()
+          callback(Result:new(Types.SUCCESS, nil, nil))
           return
         end
         if config.build_preset ~= choice then

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -228,4 +228,8 @@ function Presets.exists(cwd)
   return Presets.find_preset_files(cwd) ~= nil
 end
 
+function Presets.createEmptyBuildPreset()
+  return BuildPreset.None
+end
+
 return Presets


### PR DESCRIPTION
This pull requests fixes the behaviour I mentioned in Issue #333 (CMake build presets are required when using configure presets). It allows the user to proceed with building if a CMake configure preset has been selected but no build presets are available.

This change was implemented by creating a sentinel object for the `BuildPreset` class which represents the choice of no build preset. This choice **cannot** be specified with `build_preset = nil` as that represents the case where a build preset is yet to be selected.

Code can check for this 'no build preset wanted' state by calling `build_preset.is_none` which returns `true` in that case. 

A few `if` statements in `lua/cmake-tools/init.lua` are modified to ensure that `build_preset` is not used when set to `BuildPreset.None`.

In addition, a minor typo causing undersired behaviour was fixed on line 33 (previously line 21) of `lua/cmake-tools/build_preset.lua`.