### PR TITLE
refactor(build-preset): make 'None' option an actual preset (#333)

### DIFF
--- a/lua/cmake-tools/build_preset.lua
+++ b/lua/cmake-tools/build_preset.lua
@@ -9,6 +9,10 @@ function BuildPreset:new(cwd, obj)
   instance.environment = instance.environment or {}
   instance.cwd = cwd
 
+  if instance.valid == nil then
+    instance.valid = true
+  end
+
   return instance
 end
 
@@ -29,6 +33,10 @@ function BuildPreset:get_build_type()
     return nil
   end
   return self.configuration
+end
+
+function BuildPreset:is_valid()
+  return self.valid
 end
 
 return BuildPreset

--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -129,6 +129,8 @@ function Presets:parse(cwd)
     build_preset = createBuildPreset(build_preset)
   end
 
+  table.insert(instance.buildPresets, createBuildPreset({ name = "None", valid = false }))
+
   return instance
 end
 


### PR DESCRIPTION
This commit changes the handling of the None option of the build-preset selection to be an actual preset. A new `is_valid` function checks if the preset was created from the presets file or if it was added "by hand" for the option to have no (real) build-preset selected