### PR TITLE
fix: convert session data build_target to table if needed

### DIFF
--- a/lua/cmake-tools/session.lua
+++ b/lua/cmake-tools/session.lua
@@ -74,6 +74,9 @@ function session.update(config, old_config)
     end
     if old_config.build_target then
       config.build_target = old_config.build_target
+      if type(config.build_target) ~= "table" then -- Backwards compatibility (could be removed after a grace period) see PR!332
+        config.build_target = { config.build_target }
+      end
     end
     if old_config.launch_target then
       config.launch_target = old_config.launch_target


### PR DESCRIPTION
PR #332 introduced handling for multiple targets. Yet, old session data still has the build_target stored as string resulting in an error when trying to unpack the string when forming the --target arg. This PR fixes this issue by converting old session data to the new format, if needed