### PR TITLE
fix: initialize buildPresets to empty table before insert

### DIFF
--- a/lua/cmake-tools/presets.lua
+++ b/lua/cmake-tools/presets.lua
@@ -125,7 +125,8 @@ function Presets:parse(cwd)
     preset = createPreset(preset)
   end
 
-  for _, build_preset in ipairs(instance.buildPresets or {}) do
+  instance.buildPresets = instance.buildPresets or {}
+  for _, build_preset in ipairs(instance.buildPresets) do
     build_preset = createBuildPreset(build_preset)
   end
 


### PR DESCRIPTION
Prevents 'bad argument #1 to insert (table expected, got nil)' crash when CMakePresets.json has no buildPresets key.