### PR TITLE
use overseer's default strategy for cmake runner

### DIFF
--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -104,11 +104,11 @@ local const = {
       },
       overseer = {
         new_task_opts = {
-          strategy = {
-            "terminal",
-          },
+          strategy = nil,
         }, -- options to pass into the `overseer.new_task` command
-        on_new_task = function(task) end, -- a function that gets overseer.Task when it is created, before calling `task:start`
+        on_new_task = function(task)
+          require("overseer").open({ enter = false, direction = "right" })
+        end, -- a function that gets overseer.Task when it is created, before calling `task:start`
       },
       vimux = {},
       terminal = {


### PR DESCRIPTION
the pr #358 fixed the issue affecting the overseer strategy while using the cmake_executor, but similar changes weren't provided for the cmake_runner. This pr reflects the changes in the cmake_runner