### PR TITLE
Fix overwriting of default CMake variants

### DIFF
--- a/lua/cmake-tools/variants.lua
+++ b/lua/cmake-tools/variants.lua
@@ -224,19 +224,14 @@ function variants.build_arglist(variant, cwd)
   local function build_simple(build_type)
     return { "-D", "CMAKE_BUILD_TYPE:STRING=" .. build_type }
   end
-
-  -- start building arglist
-
-  -- check if the chosen variants is one of the defaults
-  for _, defaultvar in pairs(DEFAULT_VARIANTS) do
-    if variant == defaultvar then
-      return build_simple(variant) -- if so, build the simple arglist and return
-    end
-  end
-
-  -- otherwise, find the config file to parse
   local config = variants.parse(cwd)
   if not config then
+    -- check if the chosen variants is one of the defaults
+    for _, defaultvar in pairs(DEFAULT_VARIANTS) do
+      if variant == defaultvar then
+        return build_simple(variant) -- if so, build the simple arglist and return
+      end
+    end
     return {} -- silent error (empty arglist) if no config file found
   end
 


### PR DESCRIPTION
Fixes the following issue:

**Preconditions**
- The project has at least one CMake option.
- The project contains a cmake-variants.yaml file with default variants such as debug. Example here: [CMake Variants](https://github.com/Civitasv/cmake-tools.nvim/blob/master/docs/cmake_variants.md)

**Steps**:
1. Edit an option to a non-default value within the settings section of cmake-variants.yaml.
2. Check the generated CMakeCache.txt.

**Expected**: The option change is reflected in CMakeCache.txt.
**Actual**: The change is not reflected.

Here is a small hello world project for easier testing: [hello.zip](https://github.com/user-attachments/files/25634883/hello.zip)


I noticed that cmake-tools generates a default argument list if the variant name happens to match one of the defaults. I would assume this is intended behavior when no YAML file exists, but it also occurs when the file is present. I tested vscode-cmake-tools, and there the settings change works correctly.