### PR TITLE
fix: CMakeRun now actually uses vim.o.shell on Windows

### DIFF
--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -580,7 +580,9 @@ local get_last_exit_code = function()
     print("Could not find last tmp file conaining exit code")
     return nil
   end
-  return tonumber(file:read("*n"))
+  local code = tonumber(file:read("*n"))
+  file:close()
+  return code
 end
 
 ---


### PR DESCRIPTION
# Description
On windows, the terminal handling of CMakeRun is kind of wonky.  
- There is checks for pwsh and powershell, but everything is ran using `cmd /C`. 
- Syntax is passed to cmd that would be for powershell OR pwsh that cmd just doesn't understand.
- Some incorrect syntax is used in powershell/pwsh (assuming it was ran in either).
- No bash support for windows, `cmd /C` is still passed, but is unable execute properly.

# Example program
```
#include <stdio.h>

int main(int argc, char* argv[])
{
    for(int i = 1; i < argc; i++)
    {
        printf("arg %d: %s\n", i, argv[i]);
    }

    puts("All done");

    return 69;
}

```
## cmd Before
```
cmd /C "cd C:\Users\uttervitriol\source\test\out\Release\Release\ && .\test.exe& echo %errorlevel%
 > C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\exit_code && del /Q C:\Users\uttervitriol\AppData\Local\nvim-data\c
make-tools-tmp\.lock"
All done
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ ls

    Directory: C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---            3/6/2026    17:46              5 exit_code
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ cat .\exit_code
0
```
## cmd After
```
cmd /V:ON /C "cd C:\Users\uttervitriol\source\test\out\Release\Release\ && .\test.exe & echo !erro
rlevel! > C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\exit_code && del /Q C:\Users\uttervitriol\AppData\Local\nvim
-data\cmake-tools-tmp\.lock"
All done
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ ls

    Directory: C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---            3/6/2026    17:48              6 exit_code
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ cat .\exit_code
69
```
## pwsh (Powershell 7) Before
```
cmd /C "cd C:\Users\uttervitriol\source\test\out\Release\Release\ && .\test.exe; echo $LASTEXITCODE > C:\Users\uttervitriol\AppD
ata\Local\nvim-data\cmake-tools-tmp\exit_code -and Remove-Item C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\.lock" 
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ ls

    Directory: C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---            3/6/2026    16:55              0 .lock
-a---            3/6/2026    16:55            143 exit_code
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ cat .\exit_code
arg 1: ;
arg 2: echo
arg 3: 69
arg 4: -and
arg 5: Remove-Item
arg 6: C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\.lock
All done
```
## pwsh (Powershell 7) After
```
pwsh -Command "cd C:\Users\uttervitriol\source\test\out\Release\Release\ && .\test.exe; `$ec = `$LASTEXITCODE; Set-Content -Path
 C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\exit_code -Value `$ec; Remove-Item C:\Users\uttervitriol\AppData\Loca
l\nvim-data\cmake-tools-tmp\.lock" 
All done
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ ls

    Directory: C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---            3/6/2026    17:30              4 exit_code
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ cat .\exit_code
69
```

## powershell Before
```
cmd /C "cd C:\Users\uttervitriol\source\test\out\Release\Release\ && .\test.exe; echo $LASTEXI
TCODE > C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\exit_code -and Remove-Item C:\Users\uttervitriol\AppData\Local
\nvim-data\cmake-tools-tmp\.lock"


```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ ls

    Directory: C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---            3/6/2026    17:06              0 .lock
-a---            3/6/2026    17:06            132 exit_code
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ cat .\exit_code
arg 1: ;
arg 2: echo
arg 3: -and
arg 4: Remove-Item
arg 5: C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\.lock
All done
```
## powershell After
```
powershell -Command "cd C:\Users\uttervitriol\source\test\out\Release\Release\; .\test.exe; `$
ec = `$LASTEXITCODE; Set-Content -Path C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\exit_code -Value `$ec; Remove-I
tem C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\.lock" 
All done
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ ls

    Directory: C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---            3/6/2026    17:33              4 exit_code
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ cat .\exit_code
69
```
## bash (mingw64 (git bash)) Before
```
$ cmd /C "cd C:\Users\uttervitriol\source\test\out\Release\Release\ && .\test.exe& echo %errorlevel% > C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\exit_
code && del /Q C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp\.lock" 
Microsoft Windows [Version 10.0.26200.7840]
(c) Microsoft Corporation. All rights reserved.

C:\Users\uttervitriol\source\test>
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ ls

    Directory:
C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---            3/6/2026    17:11              0 .lock
```
## bash (mingw64 (git bash)) After
```
$ cd C:/Users/uttervitriol/source/test/out/Release/Release/ && ./test.exe; echo $? > C:/Users/uttervitriol/AppData/Local/nvim-data/cmake-tools-tmp/exit_code && \rm -f C:/
Users/uttervitriol/AppData/Local/nvim-data/cmake-tools-tmp/.lock 
All done
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ ls

    Directory:
C:\Users\uttervitriol\AppData\Local\nvim-data\cmake-tools-tmp

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---            3/6/2026    17:35              3 exit_code
```
```
┖[~\AppData\Local\nvim-data\cmake-tools-tmp]
└─Δ cat .\exit_code
69
```
# After changes



For each of the above vim.o.shell was set to cmd/pwsh/powershell/bash respectively.
Though, the changes should support full paths to shell binaries.

I did a quick test on my ubuntu machine to make sure it still works on nix.
Basically solves #331.